### PR TITLE
fix(device): impede reconexão automática após disconnect manual

### DIFF
--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -52,6 +52,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
     private _onStatusUnsub?: () => void;
     private _onQRCodeUnsub?: () => void;
     private _onContactUnsub?: () => void;
+    private stopped = false;
 
     constructor(
         private readonly mediaManager: MediaManager,
@@ -224,11 +225,13 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     connect() {
         if (this.wss.connected) return;
+        this.stopped = false;
         this.wss.connect();
     }
 
     disconnect() {
         if (this.wss.disconnected) return;
+        this.stopped = true;
         this.wss.disconnect();
     }
 
@@ -242,6 +245,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     private onDisconnect() {
         this.device.status = "disconnected";
+        if (this.stopped) return;
         if (this.wss.active) return;
         this.reconnect();
     }

--- a/src/test/device/DeviceConnection.test.ts
+++ b/src/test/device/DeviceConnection.test.ts
@@ -103,6 +103,24 @@ const offerProps = (id: string) => ({
 // Tests
 // ---------------------------------------------------------------------------
 
+describe("DeviceConnection — manual disconnect", () => {
+    it("does not auto-reconnect after manual disconnect()", async () => {
+        vi.useFakeTimers();
+        const { dc, socket } = makeDeviceConnection();
+        socket.disconnected = false;
+        socket.connect.mockClear();
+
+        dc.disconnect();
+        expect(socket.disconnect).toHaveBeenCalledTimes(1);
+
+        socket.receive("disconnect");
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(socket.connect).not.toHaveBeenCalled();
+        vi.useRealTimers();
+    });
+});
+
 describe("DeviceConnection — calls map cleanup", () => {
     describe("official incoming call", () => {
         it("adds call to map when offer arrives", () => {


### PR DESCRIPTION
## Resumo
- `Wavoip.removeDevices(tokens)` chama `DeviceConnection.disconnect()` para cada token, fechando manualmente o socket.io.
- No socket.io v4, após um disconnect manual `socket.active` passa a ser `false`. O handler `onDisconnect` protege a reconexão com `if (this.wss.active) return;`, então essa proteção **não** dispara — `reconnect()` agenda um novo `wss.connect()` 1s depois, reabrindo o socket.
- Consequência: o consumidor não consegue derrubar de fato o socket de um device pela API pública. Depois de `removeDevices` o socket volta a aparecer.

## Correção
Rastrear a intenção de encerramento por meio de uma flag `stopped`:
- `disconnect()` seta `stopped = true` antes de chamar `wss.disconnect()`.
- `connect()` limpa `stopped` antes de `wss.connect()`.
- `onDisconnect()` retorna cedo quando `stopped` é `true`, mantendo quedas iniciadas pelo servidor/rede no caminho de reconexão atual.

## Plano de teste
- [x] `pnpm lint`
- [x] `pnpm test` — 119 testes passando, incluindo o novo caso "does not auto-reconnect after manual disconnect()"
- [x] `pnpm build`