### PR TITLE
fix(webrtc): cap ICE gathering and surface diagnostics events

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,3 +20,4 @@
 ## Referência
 
 * [Tipos](types.md)
+* [Solução de Problemas](troubleshooting.md)

--- a/docs/calls/active.md
+++ b/docs/calls/active.md
@@ -51,15 +51,17 @@ await call.end()
 
 Assine com `call.on(evento, callback)`. Retorna uma função `Unsubscribe`.
 
-| Evento             | Payload           | Descrição                                                    |
-| ------------------ | ----------------- | ------------------------------------------------------------ |
-| `ended`            | —                 | Chamada encerrada (por qualquer uma das partes).             |
-| `peerMute`         | —                 | Parte remota silenciou o microfone.                          |
-| `peerUnmute`       | —                 | Parte remota ativou o microfone.                             |
-| `connectionStatus` | `TransportStatus` | Estado de conexão do transporte de mídia mudou.              |
-| `stats`            | `CallStats`       | Estatísticas periódicas de qualidade (RTT, perda de pacotes).|
-| `error`            | `string`          | Ocorreu um erro no nível de transporte.                      |
-| `status`           | `CallStatus`      | Status da chamada mudou.                                     |
+| Evento              | Payload              | Descrição                                                                                                |
+| ------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
+| `ended`             | —                    | Chamada encerrada (por qualquer uma das partes).                                                         |
+| `peerMute`          | —                    | Parte remota silenciou o microfone.                                                                      |
+| `peerUnmute`        | —                    | Parte remota ativou o microfone.                                                                         |
+| `connectionStatus`  | `TransportStatus`    | Estado de conexão do transporte de mídia mudou.                                                          |
+| `stats`             | `CallStats`          | Estatísticas periódicas de qualidade (RTT, perda de pacotes).                                            |
+| `error`             | `string`             | Ocorreu um erro no nível de transporte.                                                                  |
+| `status`            | `CallStatus`         | Status da chamada mudou.                                                                                 |
+| `iceDiagnostics`    | `IceDiagnostics`     | Snapshot do gathering ICE (chamadas oficiais). Veja [Solução de Problemas](../troubleshooting.md).      |
+| `connectivityIssue` | `ConnectivityIssue`  | Problema de conectividade detectado durante a chamada. Veja [Solução de Problemas](../troubleshooting.md). |
 
 ```typescript
 call.on("ended", () => {

--- a/docs/calls/incoming.md
+++ b/docs/calls/incoming.md
@@ -73,13 +73,15 @@ const { err } = await offer.reject()
 
 Assine com `offer.on(evento, callback)`. Retorna uma função `Unsubscribe`.
 
-| Evento               | Payload      | Descrição                                                     |
-| -------------------- | ------------ | ------------------------------------------------------------- |
-| `acceptedElsewhere`  | —            | Outro cliente (aba/dispositivo) aceitou a chamada.            |
-| `rejectedElsewhere`  | —            | Outro cliente rejeitou a chamada.                             |
-| `unanswered`         | —            | Oferta expirou sem resposta.                                  |
-| `ended`              | —            | Chamada encerrada antes de ser atendida.                      |
-| `status`             | `CallStatus` | Status da chamada mudou.                                      |
+| Evento               | Payload              | Descrição                                                                                                |
+| -------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
+| `acceptedElsewhere`  | —                    | Outro cliente (aba/dispositivo) aceitou a chamada.                                                       |
+| `rejectedElsewhere`  | —                    | Outro cliente rejeitou a chamada.                                                                        |
+| `unanswered`         | —                    | Oferta expirou sem resposta.                                                                             |
+| `ended`              | —                    | Chamada encerrada antes de ser atendida.                                                                 |
+| `status`             | `CallStatus`         | Status da chamada mudou.                                                                                 |
+| `iceDiagnostics`     | `IceDiagnostics`     | Snapshot do gathering ICE após `accept()`. Veja [Solução de Problemas](../troubleshooting.md).          |
+| `connectivityIssue`  | `ConnectivityIssue`  | Problema de conectividade detectado. Veja [Solução de Problemas](../troubleshooting.md).                |
 
 ```typescript
 offer.on("acceptedElsewhere", () => {

--- a/docs/calls/outgoing.md
+++ b/docs/calls/outgoing.md
@@ -70,13 +70,15 @@ call.on("unanswered", () => console.log("Sem resposta"))
 
 Assine com `call.on(evento, callback)`. Retorna uma função `Unsubscribe`.
 
-| Evento       | Payload        | Descrição                                               |
-| ------------ | -------------- | ------------------------------------------------------- |
-| `peerAccept` | `CallActive`   | Destinatário atendeu — um `CallActive` é fornecido.     |
-| `peerReject` | —              | Destinatário recusou a chamada.                         |
-| `unanswered` | —              | Chamada expirou sem resposta.                           |
-| `ended`      | —              | Chamada encerrada (ex: destinatário desligou antes de atender). |
-| `status`     | `CallStatus`   | Status da chamada mudou.                                |
+| Evento              | Payload              | Descrição                                                                                                |
+| ------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
+| `peerAccept`        | `CallActive`         | Destinatário atendeu — um `CallActive` é fornecido.                                                      |
+| `peerReject`        | —                    | Destinatário recusou a chamada.                                                                          |
+| `unanswered`        | —                    | Chamada expirou sem resposta.                                                                            |
+| `ended`             | —                    | Chamada encerrada (ex: destinatário desligou antes de atender).                                          |
+| `status`            | `CallStatus`         | Status da chamada mudou.                                                                                 |
+| `iceDiagnostics`    | `IceDiagnostics`     | Snapshot do gathering ICE (chamadas oficiais). Veja [Solução de Problemas](../troubleshooting.md).      |
+| `connectivityIssue` | `ConnectivityIssue`  | Problema de conectividade detectado. Veja [Solução de Problemas](../troubleshooting.md).                |
 
 ```typescript
 call.on("peerAccept", (active) => {

--- a/docs/getting-started/initialization.md
+++ b/docs/getting-started/initialization.md
@@ -13,13 +13,20 @@ import { Wavoip } from "@wavoip/wavoip-api"
 const wavoip = new Wavoip({
     tokens: ["token-1", "token-2"],
     platform?: string,        // opcional — identifica a plataforma do cliente
+    language?: "pt-BR" | "en" | "es",  // opcional — idioma de mensagens da lib
+    iceConfig?: {             // opcional — controla ICE/STUN em chamadas WebRTC
+        gatheringTimeoutMs?: number,
+        iceServers?: RTCIceServer[],
+    },
 })
 ```
 
-| Parâmetro  | Tipo       | Obrigatório | Descrição                                                       |
-| ---------- | ---------- | ----------- | --------------------------------------------------------------- |
-| `tokens`   | `string[]` | Sim         | Um ou mais tokens de dispositivo Wavoip. Duplicatas são ignoradas. |
-| `platform` | `string`   | Não         | Identificador de plataforma enviado ao servidor na conexão.     |
+| Parâmetro   | Tipo        | Obrigatório | Descrição                                                                                                                              |
+| ----------- | ----------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `tokens`    | `string[]`  | Sim         | Um ou mais tokens de dispositivo Wavoip. Duplicatas são ignoradas.                                                                     |
+| `platform`  | `string`    | Não         | Identificador de plataforma enviado ao servidor na conexão.                                                                            |
+| `language`  | `Language`  | Não         | Idioma das mensagens emitidas pela biblioteca. Padrão: `pt-BR`.                                                                        |
+| `iceConfig` | `IceConfig` | Não         | Configuração ICE para chamadas WebRTC. Veja a seção abaixo. Útil em redes onde o STUN padrão é bloqueado ou para usar STUN/TURN próprio. |
 
 Cada token cria uma conexão WebSocket persistente com a infraestrutura Wavoip. A biblioteca começa a se conectar imediatamente na construção — nenhuma chamada explícita a `.connect()` é necessária.
 
@@ -180,3 +187,30 @@ const { microphone, speaker } = wavoip.multimedia
 // microphone: MediaDeviceInfo | undefined
 // speaker:    MediaDeviceInfo | undefined
 ```
+
+---
+
+## `iceConfig` — configuração ICE/STUN
+
+Controla como o transporte WebRTC reúne candidatos ICE em chamadas oficiais.
+
+```typescript
+const wavoip = new Wavoip({
+    tokens: ["..."],
+    iceConfig: {
+        gatheringTimeoutMs: 2500,        // padrão: 2500ms
+        iceServers: [                    // padrão: três STUNs públicos
+            { urls: ["stun:stun.l.google.com:19302", "stun:stun.cloudflare.com:3478"] },
+        ],
+    },
+})
+```
+
+| Campo                | Tipo             | Padrão                                                                                       | Descrição                                                                                                                                  |
+| -------------------- | ---------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `gatheringTimeoutMs` | `number`         | `2500`                                                                                       | Tempo máximo para reunir candidatos ICE antes de prosseguir com o SDP. Evita travas longas quando STUN está bloqueado/lento.              |
+| `iceServers`         | `RTCIceServer[]` | `[stun:stun.l.google.com:19302, stun:stun1.l.google.com:19302, stun:stun.cloudflare.com:3478]` | Lista de servidores ICE passada ao `RTCPeerConnection`. Use para apontar para um STUN/TURN próprio.                                       |
+
+{% hint style="info" %}
+Por padrão a biblioteca não usa TURN. Em redes com NAT simétrico em ambos os lados, a chamada pode falhar — veja `connectivityIssue: "SYMMETRIC_NAT_SUSPECTED"` em [Solução de Problemas](../troubleshooting.md).
+{% endhint %}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,133 @@
+---
+description: Diagnostique e resolva problemas de conectividade em chamadas WebRTC.
+icon: stethoscope
+---
+
+# Solução de Problemas
+
+Esta página documenta os eventos de diagnóstico emitidos pela biblioteca durante chamadas WebRTC oficiais e como interpretá-los. Use-os para detectar problemas de rede no cliente e orientar o usuário ou o suporte.
+
+## Eventos de diagnóstico
+
+Todas as facades de chamada (`Offer`, `CallOutgoing`, `CallActive`) expõem dois eventos relacionados a diagnóstico:
+
+### `iceDiagnostics`
+
+Disparado uma vez ao fim do gathering ICE (sucesso ou timeout). Contém um snapshot do que foi coletado.
+
+```typescript
+call.on("iceDiagnostics", (diag) => {
+    console.log("gatheringDurationMs", diag.gatheringDurationMs)
+    console.log("gatheringTimedOut", diag.gatheringTimedOut)
+    console.log("candidates", diag.candidatesByType)
+    console.log("stunReached", diag.stunReached)
+    console.log("turnReached", diag.turnReached)
+})
+```
+
+| Campo                  | Tipo                          | Descrição                                                                                                          |
+| ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `gatheringDurationMs`  | `number`                      | Tempo total gasto reunindo candidatos ICE.                                                                         |
+| `gatheringTimedOut`    | `boolean`                     | `true` quando o gathering foi interrompido pelo `gatheringTimeoutMs` (não atingiu `iceGatheringState === "complete"`). |
+| `candidatesByType`     | `Record<IceCandidateKind, n>` | Contagem por tipo (`host`, `srflx`, `prflx`, `relay`).                                                             |
+| `stunReached`          | `boolean`                     | `true` quando ao menos um candidato `srflx` foi reunido (STUN respondeu).                                          |
+| `turnReached`          | `boolean`                     | `true` quando ao menos um candidato `relay` foi reunido (TURN respondeu).                                          |
+
+### `connectivityIssue`
+
+Disparado uma vez por tipo de problema detectado durante a chamada.
+
+```typescript
+call.on("connectivityIssue", (issue) => {
+    switch (issue) {
+        case "STUN_UNREACHABLE":          /* ... */ break
+        case "ICE_GATHERING_TIMEOUT":     /* ... */ break
+        case "ICE_CONNECTION_FAILED":     /* ... */ break
+        case "NO_HOST_CANDIDATES":        /* ... */ break
+        case "SYMMETRIC_NAT_SUSPECTED":   /* ... */ break
+    }
+})
+```
+
+## Catálogo de problemas
+
+### `STUN_UNREACHABLE`
+
+**O que é:** Nenhum candidato `srflx` foi reunido antes do timeout. Indica que os servidores STUN configurados não responderam.
+
+**Causas comuns:**
+
+* Firewall corporativo bloqueando UDP (porta 3478 ou 19302).
+* DNS lento ou bloqueio do hostname do servidor STUN.
+* ISP filtrando tráfego UDP.
+
+**Como agir:**
+
+* Use a função [`runStunProbe`](#runstunprobe) para verificar quais servidores estão acessíveis.
+* Configure `iceConfig.iceServers` com servidores próprios.
+* Se mesmo assim falhar, considere TURN.
+
+### `ICE_GATHERING_TIMEOUT`
+
+**O que é:** O gathering atingiu o `gatheringTimeoutMs` antes de `iceGatheringState === "complete"`. A chamada prossegue com os candidatos já reunidos.
+
+**Causas comuns:** As mesmas de `STUN_UNREACHABLE`, ou um servidor STUN/TURN lento.
+
+**Como agir:** Verifique a rede do usuário. Se `stunReached` for `true` no `iceDiagnostics`, a chamada provavelmente conecta mesmo assim.
+
+### `ICE_CONNECTION_FAILED`
+
+**O que é:** Após o gathering, o `RTCPeerConnection` falhou em estabelecer transporte de mídia (`iceConnectionState === "failed"`).
+
+**Causas comuns:**
+
+* NAT simétrico em ambos os lados sem TURN disponível.
+* Firewall bloqueando tráfego de mídia (UDP).
+* Falha no relay do servidor.
+
+**Como agir:** Confirme se há rota UDP livre entre cliente e servidor. Encaminhe para o suporte com o relatório de diagnóstico.
+
+### `NO_HOST_CANDIDATES`
+
+**O que é:** O navegador não emitiu candidatos do tipo `host` (IP local). Raro.
+
+**Causas comuns:**
+
+* mDNS desabilitado em ambientes restritos.
+* Configuração de privacidade do navegador que oculta interfaces locais.
+* VPN bloqueando interfaces.
+
+**Como agir:** Verifique configurações do navegador e VPN.
+
+### `SYMMETRIC_NAT_SUSPECTED`
+
+**O que é:** O STUN respondeu, mas após 10 segundos a conexão ICE ainda não foi estabelecida. Sugere NAT simétrico bloqueando o pareamento de candidatos sem um relay TURN.
+
+**Causas comuns:** NAT simétrico do lado do cliente (comum em redes móveis, alguns roteadores domésticos).
+
+**Como agir:** Hoje a biblioteca não traz TURN embutido. Em breve documentaremos como apontar para um servidor TURN próprio via `iceConfig.iceServers`.
+
+## `runStunProbe`
+
+Utilitário para verificar reachability de servidores STUN diretamente do navegador. Útil em telas de diagnóstico/suporte.
+
+```typescript
+import { runStunProbe } from "@wavoip/wavoip-api"
+
+const results = await runStunProbe([
+    "stun:stun.l.google.com:19302",
+    "stun:stun.cloudflare.com:3478",
+])
+// [{ server, reachable, latencyMs? }, ...]
+```
+
+| Parâmetro    | Tipo       | Padrão | Descrição                              |
+| ------------ | ---------- | ------ | -------------------------------------- |
+| `servers`    | `string[]` | —      | URLs `stun:` para testar em paralelo.  |
+| `timeoutMs?` | `number`   | `3000` | Limite para considerar inacessível.    |
+
+Cada resultado é `{ server, reachable: boolean, latencyMs?: number }`. `latencyMs` só vem preenchido quando o servidor respondeu com um candidato `srflx`.
+
+{% hint style="info" %}
+A função cria `RTCPeerConnection`s descartáveis — não requer nenhuma chamada ativa.
+{% endhint %}

--- a/src/Wavoip.ts
+++ b/src/Wavoip.ts
@@ -2,6 +2,7 @@ import type { CallOutgoing } from "@/modules/call/CallOutgoing";
 import type { Offer } from "@/modules/call/Offer";
 import { type Device, DeviceConnection } from "@/modules/device/DeviceConnection";
 import { DeviceProxy } from "@/modules/device/DeviceProxy";
+import type { IceConfig } from "@/modules/media/ICEDiagnostics";
 import { MediaManager } from "@/modules/media/MediaManager";
 import { EventEmitter } from "@/modules/shared/EventEmitter";
 import { type Language, setLanguage } from "@/modules/shared/i18n";
@@ -19,12 +20,13 @@ export class Wavoip extends EventEmitter<Events> {
         tokens: string[];
         platform?: string;
         language?: Language;
+        iceConfig?: IceConfig;
     }) {
         super();
 
         setLanguage(params.language ?? "pt-BR");
 
-        this.mediaManager = new MediaManager();
+        this.mediaManager = new MediaManager({ iceConfig: params.iceConfig });
 
         for (const token of [...new Set(params.tokens)]) {
             const device = new DeviceConnection(this.mediaManager, token, params.platform);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,15 @@ export type { DeviceStatus, Contact } from "@/modules/device/Device";
 export type { Device, DeviceEvents } from "@/modules/device/DeviceConnection";
 
 export type { TransportStatus } from "@/modules/media/ITransport";
+export type {
+    ConnectivityIssue,
+    IceCandidateKind,
+    IceConfig,
+    IceDiagnostics,
+} from "@/modules/media/ICEDiagnostics";
 export type { MediaManagerState } from "@/modules/media/MediaManager";
+export type { StunProbeResult } from "@/modules/media/StunProbe";
+export { runStunProbe } from "@/modules/media/StunProbe";
 export type { Unsubscribe } from "@/modules/shared/EventEmitter";
 export type { Language } from "@/modules/shared/i18n";
 

--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -5,7 +5,8 @@ import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
-import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
+import type { Unsubscribe } from "@/modules/shared/EventEmitter";
+import { StickyDiagnosticsEmitter } from "@/modules/shared/StickyDiagnosticsEmitter";
 
 export type CallActiveEvents = {
     error: [err: string];
@@ -58,40 +59,17 @@ export function CallActiveProxy(
         onEnd: (call: Call) => void;
     },
 ): CallActive {
-    const emitter = new EventEmitter<CallActiveEvents>();
+    const emitter = new StickyDiagnosticsEmitter<CallActiveEvents>();
 
-    bus.on("failed", (err) => {
-        emitter.emit("error", err);
-    });
-    bus.on("peerMuted", (muted) => {
-        if (muted) emitter.emit("peerMute");
-        else emitter.emit("peerUnmute");
-    });
-    bus.on("ended", () => {
-        emitter.emit("ended");
-    });
-    bus.on("stats", (stats) => {
-        emitter.emit("stats", stats);
-    });
-    bus.on("serverStats", (stats) => {
-        emitter.emit("serverStats", stats);
-    });
-    bus.on("connectionStatus", (status) => {
-        emitter.emit("connectionStatus", status);
-    });
-    bus.on("status", (status) => {
-        emitter.emit("status", status);
-    });
-    let lastIceDiagnostics: IceDiagnostics | null = null;
-    const emittedIssues = new Set<ConnectivityIssue>();
-    bus.on("iceDiagnostics", (diag) => {
-        lastIceDiagnostics = diag;
-        emitter.emit("iceDiagnostics", diag);
-    });
-    bus.on("connectivityIssue", (issue) => {
-        emittedIssues.add(issue);
-        emitter.emit("connectivityIssue", issue);
-    });
+    bus.on("failed", (err) => emitter.emit("error", err));
+    bus.on("peerMuted", (muted) => emitter.emit(muted ? "peerMute" : "peerUnmute"));
+    bus.on("ended", () => emitter.emit("ended"));
+    bus.on("stats", (stats) => emitter.emit("stats", stats));
+    bus.on("serverStats", (stats) => emitter.emit("serverStats", stats));
+    bus.on("connectionStatus", (status) => emitter.emit("connectionStatus", status));
+    bus.on("status", (status) => emitter.emit("status", status));
+    bus.on("iceDiagnostics", (diag) => emitter.emit("iceDiagnostics", diag));
+    bus.on("connectivityIssue", (issue) => emitter.emit("connectivityIssue", issue));
 
     let onErrorUnsub: Unsubscribe | undefined;
     let onPeerMuteUnsub: Unsubscribe | undefined;
@@ -128,14 +106,7 @@ export function CallActiveProxy(
         },
 
         on<T extends keyof CallActiveEvents>(event: T, callback: (...args: CallActiveEvents[T]) => void): Unsubscribe {
-            const unsub = emitter.on(event, callback);
-            if (event === "iceDiagnostics" && lastIceDiagnostics) {
-                (callback as (d: IceDiagnostics) => void)(lastIceDiagnostics);
-            }
-            if (event === "connectivityIssue") {
-                for (const issue of emittedIssues) (callback as (i: ConnectivityIssue) => void)(issue);
-            }
-            return unsub;
+            return emitter.on(event, callback);
         },
 
         /** @deprecated Use `on("error", callback)` instead. */

--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -2,6 +2,7 @@ import type { CallBus } from "@/modules/call/CallBus";
 import type { CallPeer } from "@/modules/call/Peer";
 import type { CallStats, ServerCallStats } from "@/modules/call/Stats";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
@@ -15,6 +16,8 @@ export type CallActiveEvents = {
     serverStats: [stats: ServerCallStats];
     connectionStatus: [status: TransportStatus];
     status: [status: CallStatus];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export interface CallActive {
@@ -78,6 +81,12 @@ export function CallActiveProxy(
     });
     bus.on("status", (status) => {
         emitter.emit("status", status);
+    });
+    bus.on("iceDiagnostics", (diag) => {
+        emitter.emit("iceDiagnostics", diag);
+    });
+    bus.on("connectivityIssue", (issue) => {
+        emitter.emit("connectivityIssue", issue);
     });
 
     let onErrorUnsub: Unsubscribe | undefined;

--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -82,10 +82,14 @@ export function CallActiveProxy(
     bus.on("status", (status) => {
         emitter.emit("status", status);
     });
+    let lastIceDiagnostics: IceDiagnostics | null = null;
+    const emittedIssues = new Set<ConnectivityIssue>();
     bus.on("iceDiagnostics", (diag) => {
+        lastIceDiagnostics = diag;
         emitter.emit("iceDiagnostics", diag);
     });
     bus.on("connectivityIssue", (issue) => {
+        emittedIssues.add(issue);
         emitter.emit("connectivityIssue", issue);
     });
 
@@ -124,7 +128,14 @@ export function CallActiveProxy(
         },
 
         on<T extends keyof CallActiveEvents>(event: T, callback: (...args: CallActiveEvents[T]) => void): Unsubscribe {
-            return emitter.on(event, callback);
+            const unsub = emitter.on(event, callback);
+            if (event === "iceDiagnostics" && lastIceDiagnostics) {
+                (callback as (d: IceDiagnostics) => void)(lastIceDiagnostics);
+            }
+            if (event === "connectivityIssue") {
+                for (const issue of emittedIssues) (callback as (i: ConnectivityIssue) => void)(issue);
+            }
+            return unsub;
         },
 
         /** @deprecated Use `on("error", callback)` instead. */

--- a/src/modules/call/CallBus.ts
+++ b/src/modules/call/CallBus.ts
@@ -88,5 +88,10 @@ export class CallBus extends EventEmitter<CallBusEvents> {
         transport.on("statsChanged", (s) => this.emit("stats", s));
         transport.on("iceDiagnostics", (d) => this.emit("iceDiagnostics", d));
         transport.on("connectivityIssue", (i) => this.emit("connectivityIssue", i));
+
+        if (transport.lastDiagnostics) this.emit("iceDiagnostics", transport.lastDiagnostics);
+        if (transport.emittedIssues) {
+            for (const issue of transport.emittedIssues) this.emit("connectivityIssue", issue);
+        }
     }
 }

--- a/src/modules/call/CallBus.ts
+++ b/src/modules/call/CallBus.ts
@@ -3,7 +3,7 @@ import type { Call, CallStatus } from "@/modules/device/Call";
 import type { DeviceSocket, MediaPlan } from "@/modules/device/WebSocket";
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
-import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
+import { StickyDiagnosticsEmitter } from "@/modules/shared/StickyDiagnosticsEmitter";
 
 type CallBusEvents = {
     status: [status: CallStatus];
@@ -28,10 +28,7 @@ type CallBusEvents = {
  * typed stream so facades (Offer, CallOutgoing, CallActive) only depend
  * on this one class instead of wiring socket/transport listeners themselves.
  */
-export class CallBus extends EventEmitter<CallBusEvents> {
-    private lastIceDiagnostics: IceDiagnostics | null = null;
-    private emittedIssues = new Set<ConnectivityIssue>();
-
+export class CallBus extends StickyDiagnosticsEmitter<CallBusEvents> {
     constructor(call: Call, socket: DeviceSocket, transport?: ITransport) {
         super();
 
@@ -76,32 +73,6 @@ export class CallBus extends EventEmitter<CallBusEvents> {
         });
 
         if (transport) this.wireTransport(transport);
-    }
-
-    /**
-     * Subscribe to bus events. For `iceDiagnostics` and `connectivityIssue`,
-     * the latest cached value(s) are immediately replayed so listeners that
-     * attach after the event already fired still receive it. This matters
-     * because facades (Offer/Active/Outgoing) are sometimes constructed
-     * after the transport has already gathered ICE.
-     */
-    on<T extends keyof CallBusEvents>(event: T, callback: (...args: CallBusEvents[T]) => void): Unsubscribe {
-        const unsub = super.on(event, callback);
-        if (event === "iceDiagnostics" && this.lastIceDiagnostics) {
-            (callback as (d: IceDiagnostics) => void)(this.lastIceDiagnostics);
-        }
-        if (event === "connectivityIssue") {
-            for (const issue of this.emittedIssues) {
-                (callback as (i: ConnectivityIssue) => void)(issue);
-            }
-        }
-        return unsub;
-    }
-
-    emit<T extends keyof CallBusEvents>(event: T, ...args: CallBusEvents[T]) {
-        if (event === "iceDiagnostics") this.lastIceDiagnostics = args[0] as IceDiagnostics;
-        if (event === "connectivityIssue") this.emittedIssues.add(args[0] as ConnectivityIssue);
-        super.emit(event, ...args);
     }
 
     /**

--- a/src/modules/call/CallBus.ts
+++ b/src/modules/call/CallBus.ts
@@ -3,7 +3,7 @@ import type { Call, CallStatus } from "@/modules/device/Call";
 import type { DeviceSocket, MediaPlan } from "@/modules/device/WebSocket";
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
-import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 
 type CallBusEvents = {
     status: [status: CallStatus];
@@ -29,6 +29,9 @@ type CallBusEvents = {
  * on this one class instead of wiring socket/transport listeners themselves.
  */
 export class CallBus extends EventEmitter<CallBusEvents> {
+    private lastIceDiagnostics: IceDiagnostics | null = null;
+    private emittedIssues = new Set<ConnectivityIssue>();
+
     constructor(call: Call, socket: DeviceSocket, transport?: ITransport) {
         super();
 
@@ -76,8 +79,35 @@ export class CallBus extends EventEmitter<CallBusEvents> {
     }
 
     /**
+     * Subscribe to bus events. For `iceDiagnostics` and `connectivityIssue`,
+     * the latest cached value(s) are immediately replayed so listeners that
+     * attach after the event already fired still receive it. This matters
+     * because facades (Offer/Active/Outgoing) are sometimes constructed
+     * after the transport has already gathered ICE.
+     */
+    on<T extends keyof CallBusEvents>(event: T, callback: (...args: CallBusEvents[T]) => void): Unsubscribe {
+        const unsub = super.on(event, callback);
+        if (event === "iceDiagnostics" && this.lastIceDiagnostics) {
+            (callback as (d: IceDiagnostics) => void)(this.lastIceDiagnostics);
+        }
+        if (event === "connectivityIssue") {
+            for (const issue of this.emittedIssues) {
+                (callback as (i: ConnectivityIssue) => void)(issue);
+            }
+        }
+        return unsub;
+    }
+
+    emit<T extends keyof CallBusEvents>(event: T, ...args: CallBusEvents[T]) {
+        if (event === "iceDiagnostics") this.lastIceDiagnostics = args[0] as IceDiagnostics;
+        if (event === "connectivityIssue") this.emittedIssues.add(args[0] as ConnectivityIssue);
+        super.emit(event, ...args);
+    }
+
+    /**
      * Attach a transport after construction (e.g. once a call is accepted
-     * and the WebRTC/WebSocket transport is ready).
+     * and the WebRTC/WebSocket transport is ready). Replays any state the
+     * transport gathered before being wired so late listeners catch up.
      */
     wireTransport(transport: ITransport): void {
         transport.on("statusChanged", (s) => {

--- a/src/modules/call/CallBus.ts
+++ b/src/modules/call/CallBus.ts
@@ -1,6 +1,7 @@
 import type { CallStats, ServerCallStats } from "@/modules/call/Stats";
 import type { Call, CallStatus } from "@/modules/device/Call";
 import type { DeviceSocket, MediaPlan } from "@/modules/device/WebSocket";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
 import { EventEmitter } from "@/modules/shared/EventEmitter";
 
@@ -17,6 +18,8 @@ type CallBusEvents = {
     peerMuted: [muted: boolean];
     stats: [stats: CallStats];
     serverStats: [stats: ServerCallStats];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 /**
@@ -83,5 +86,7 @@ export class CallBus extends EventEmitter<CallBusEvents> {
         });
         transport.on("peerMuted", (m) => this.emit("peerMuted", m));
         transport.on("statsChanged", (s) => this.emit("stats", s));
+        transport.on("iceDiagnostics", (d) => this.emit("iceDiagnostics", d));
+        transport.on("connectivityIssue", (i) => this.emit("connectivityIssue", i));
     }
 }

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -90,10 +90,14 @@ export function CallOutgoingProxy(
     bus.on("status", (status) => {
         emitter.emit("status", status);
     });
+    let lastIceDiagnostics: IceDiagnostics | null = null;
+    const emittedIssues = new Set<ConnectivityIssue>();
     bus.on("iceDiagnostics", (diag) => {
+        lastIceDiagnostics = diag;
         emitter.emit("iceDiagnostics", diag);
     });
     bus.on("connectivityIssue", (issue) => {
+        emittedIssues.add(issue);
         emitter.emit("connectivityIssue", issue);
     });
 
@@ -142,7 +146,14 @@ export function CallOutgoingProxy(
             event: T,
             callback: (...args: CallOutgoingEvents[T]) => void,
         ): Unsubscribe {
-            return emitter.on(event, callback);
+            const unsub = emitter.on(event, callback);
+            if (event === "iceDiagnostics" && lastIceDiagnostics) {
+                (callback as (d: IceDiagnostics) => void)(lastIceDiagnostics);
+            }
+            if (event === "connectivityIssue") {
+                for (const issue of emittedIssues) (callback as (i: ConnectivityIssue) => void)(issue);
+            }
+            return unsub;
         },
 
         /** @deprecated Use `on("peerAccept", callback)` instead. */

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -8,7 +8,8 @@ import type { ITransport } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { WebRTCTransport } from "@/modules/media/WebRTC";
 import { WebsocketTransport } from "@/modules/media/WebSocket";
-import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
+import type { Unsubscribe } from "@/modules/shared/EventEmitter";
+import { StickyDiagnosticsEmitter } from "@/modules/shared/StickyDiagnosticsEmitter";
 
 export type CallOutgoingEvents = {
     peerAccept: [call: CallActive];
@@ -50,7 +51,7 @@ export function CallOutgoingProxy(
     mediaManager: MediaManager,
     preBuiltTransport?: WebRTCTransport,
 ): CallOutgoing {
-    const emitter = new EventEmitter<CallOutgoingEvents>();
+    const emitter = new StickyDiagnosticsEmitter<CallOutgoingEvents>();
 
     bus.on("answered", async (mediaPlan) => {
         call.accept();
@@ -87,19 +88,9 @@ export function CallOutgoingProxy(
     bus.on("ended", () => {
         emitter.emit("ended");
     });
-    bus.on("status", (status) => {
-        emitter.emit("status", status);
-    });
-    let lastIceDiagnostics: IceDiagnostics | null = null;
-    const emittedIssues = new Set<ConnectivityIssue>();
-    bus.on("iceDiagnostics", (diag) => {
-        lastIceDiagnostics = diag;
-        emitter.emit("iceDiagnostics", diag);
-    });
-    bus.on("connectivityIssue", (issue) => {
-        emittedIssues.add(issue);
-        emitter.emit("connectivityIssue", issue);
-    });
+    bus.on("status", (status) => emitter.emit("status", status));
+    bus.on("iceDiagnostics", (diag) => emitter.emit("iceDiagnostics", diag));
+    bus.on("connectivityIssue", (issue) => emitter.emit("connectivityIssue", issue));
 
     let onPeerAcceptUnsub: Unsubscribe | undefined;
     let onPeerRejectUnsub: Unsubscribe | undefined;
@@ -146,14 +137,7 @@ export function CallOutgoingProxy(
             event: T,
             callback: (...args: CallOutgoingEvents[T]) => void,
         ): Unsubscribe {
-            const unsub = emitter.on(event, callback);
-            if (event === "iceDiagnostics" && lastIceDiagnostics) {
-                (callback as (d: IceDiagnostics) => void)(lastIceDiagnostics);
-            }
-            if (event === "connectivityIssue") {
-                for (const issue of emittedIssues) (callback as (i: ConnectivityIssue) => void)(issue);
-            }
-            return unsub;
+            return emitter.on(event, callback);
         },
 
         /** @deprecated Use `on("peerAccept", callback)` instead. */

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -3,6 +3,7 @@ import type { CallBus } from "@/modules/call/CallBus";
 import type { CallPeer } from "@/modules/call/Peer";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
 import type { DeviceSocket, MediaPlan } from "@/modules/device/WebSocket";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { WebRTCTransport } from "@/modules/media/WebRTC";
@@ -15,6 +16,8 @@ export type CallOutgoingEvents = {
     unanswered: [];
     ended: [];
     status: [status: CallStatus];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export interface CallOutgoing {
@@ -86,6 +89,12 @@ export function CallOutgoingProxy(
     });
     bus.on("status", (status) => {
         emitter.emit("status", status);
+    });
+    bus.on("iceDiagnostics", (diag) => {
+        emitter.emit("iceDiagnostics", diag);
+    });
+    bus.on("connectivityIssue", (issue) => {
+        emitter.emit("connectivityIssue", issue);
     });
 
     let onPeerAcceptUnsub: Unsubscribe | undefined;

--- a/src/modules/call/Offer.ts
+++ b/src/modules/call/Offer.ts
@@ -3,7 +3,8 @@ import type { CallBus } from "@/modules/call/CallBus";
 import type { CallPeer } from "@/modules/call/Peer";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
-import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
+import type { Unsubscribe } from "@/modules/shared/EventEmitter";
+import { StickyDiagnosticsEmitter } from "@/modules/shared/StickyDiagnosticsEmitter";
 
 export type OfferEvents = {
     acceptedElsewhere: [];
@@ -45,7 +46,7 @@ export function OfferProxy(
         onReject: (call: Call) => void;
     },
 ): Offer {
-    const emitter = new EventEmitter<OfferEvents>();
+    const emitter = new StickyDiagnosticsEmitter<OfferEvents>();
     const dispose = () => {
         bus.removeAllListeners();
         emitter.removeAllListeners();
@@ -68,16 +69,8 @@ export function OfferProxy(
         dispose();
     });
     bus.on("status", (status) => emitter.emit("status", status));
-    let lastIceDiagnostics: IceDiagnostics | null = null;
-    const emittedIssues = new Set<ConnectivityIssue>();
-    bus.on("iceDiagnostics", (diag) => {
-        lastIceDiagnostics = diag;
-        emitter.emit("iceDiagnostics", diag);
-    });
-    bus.on("connectivityIssue", (issue) => {
-        emittedIssues.add(issue);
-        emitter.emit("connectivityIssue", issue);
-    });
+    bus.on("iceDiagnostics", (diag) => emitter.emit("iceDiagnostics", diag));
+    bus.on("connectivityIssue", (issue) => emitter.emit("connectivityIssue", issue));
 
     let onAcceptedElsewhereUnsub: Unsubscribe | undefined;
     let onRejectedElsewhereUnsub: Unsubscribe | undefined;
@@ -110,14 +103,7 @@ export function OfferProxy(
         },
 
         on<T extends keyof OfferEvents>(event: T, callback: (...args: OfferEvents[T]) => void): Unsubscribe {
-            const unsub = emitter.on(event, callback);
-            if (event === "iceDiagnostics" && lastIceDiagnostics) {
-                (callback as (d: IceDiagnostics) => void)(lastIceDiagnostics);
-            }
-            if (event === "connectivityIssue") {
-                for (const issue of emittedIssues) (callback as (i: ConnectivityIssue) => void)(issue);
-            }
-            return unsub;
+            return emitter.on(event, callback);
         },
 
         /** @deprecated Use `on("acceptedElsewhere", callback)` instead. */

--- a/src/modules/call/Offer.ts
+++ b/src/modules/call/Offer.ts
@@ -2,6 +2,7 @@ import type { CallActive } from "@/modules/call/CallActive";
 import type { CallBus } from "@/modules/call/CallBus";
 import type { CallPeer } from "@/modules/call/Peer";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 
 export type OfferEvents = {
@@ -10,6 +11,8 @@ export type OfferEvents = {
     unanswered: [];
     ended: [];
     status: [status: CallStatus];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export interface Offer {
@@ -65,6 +68,8 @@ export function OfferProxy(
         dispose();
     });
     bus.on("status", (status) => emitter.emit("status", status));
+    bus.on("iceDiagnostics", (diag) => emitter.emit("iceDiagnostics", diag));
+    bus.on("connectivityIssue", (issue) => emitter.emit("connectivityIssue", issue));
 
     let onAcceptedElsewhereUnsub: Unsubscribe | undefined;
     let onRejectedElsewhereUnsub: Unsubscribe | undefined;

--- a/src/modules/call/Offer.ts
+++ b/src/modules/call/Offer.ts
@@ -68,8 +68,16 @@ export function OfferProxy(
         dispose();
     });
     bus.on("status", (status) => emitter.emit("status", status));
-    bus.on("iceDiagnostics", (diag) => emitter.emit("iceDiagnostics", diag));
-    bus.on("connectivityIssue", (issue) => emitter.emit("connectivityIssue", issue));
+    let lastIceDiagnostics: IceDiagnostics | null = null;
+    const emittedIssues = new Set<ConnectivityIssue>();
+    bus.on("iceDiagnostics", (diag) => {
+        lastIceDiagnostics = diag;
+        emitter.emit("iceDiagnostics", diag);
+    });
+    bus.on("connectivityIssue", (issue) => {
+        emittedIssues.add(issue);
+        emitter.emit("connectivityIssue", issue);
+    });
 
     let onAcceptedElsewhereUnsub: Unsubscribe | undefined;
     let onRejectedElsewhereUnsub: Unsubscribe | undefined;
@@ -102,7 +110,14 @@ export function OfferProxy(
         },
 
         on<T extends keyof OfferEvents>(event: T, callback: (...args: OfferEvents[T]) => void): Unsubscribe {
-            return emitter.on(event, callback);
+            const unsub = emitter.on(event, callback);
+            if (event === "iceDiagnostics" && lastIceDiagnostics) {
+                (callback as (d: IceDiagnostics) => void)(lastIceDiagnostics);
+            }
+            if (event === "connectivityIssue") {
+                for (const issue of emittedIssues) (callback as (i: ConnectivityIssue) => void)(issue);
+            }
+            return unsub;
         },
 
         /** @deprecated Use `on("acceptedElsewhere", callback)` instead. */

--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -160,7 +160,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
         let mediaPlan: MediaPlan;
         let preBuiltTransport: WebRTCTransport | undefined;
         if (this.device.callType === "OFFICIAL") {
-            preBuiltTransport = new WebRTCTransport(this.mediaManager);
+            preBuiltTransport = new WebRTCTransport(this.mediaManager, undefined, this.mediaManager.iceConfig);
             try {
                 const sdp = await preBuiltTransport.createOffer();
                 mediaPlan = { type: "webRTC", sdp };
@@ -320,7 +320,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
     }
 
     private async acceptWebRTCOffer(call: Call, bus: CallBus, mediaPlan: MediaPlanWebRTC): Promise<CallActive> {
-        const webRTC = new WebRTCTransport(this.mediaManager, mediaPlan.sdp);
+        const webRTC = new WebRTCTransport(this.mediaManager, mediaPlan.sdp, this.mediaManager.iceConfig);
         await webRTC.start();
 
         const answer = await webRTC.answer;

--- a/src/modules/media/ICEDiagnostics.ts
+++ b/src/modules/media/ICEDiagnostics.ts
@@ -1,0 +1,38 @@
+export type IceCandidateKind = "host" | "srflx" | "prflx" | "relay";
+
+export type IceDiagnostics = {
+    gatheringDurationMs: number;
+    gatheringTimedOut: boolean;
+    candidatesByType: Record<IceCandidateKind, number>;
+    stunReached: boolean;
+    turnReached: boolean;
+    selectedCandidatePair?: {
+        local: IceCandidateKind;
+        remote: IceCandidateKind;
+        rtt?: number;
+    };
+};
+
+export type ConnectivityIssue =
+    | "STUN_UNREACHABLE"
+    | "ICE_GATHERING_TIMEOUT"
+    | "ICE_CONNECTION_FAILED"
+    | "NO_HOST_CANDIDATES"
+    | "SYMMETRIC_NAT_SUSPECTED";
+
+export type IceConfig = {
+    gatheringTimeoutMs?: number;
+    iceServers?: RTCIceServer[];
+};
+
+export const DEFAULT_ICE_GATHERING_TIMEOUT_MS = 2500;
+
+export const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
+    {
+        urls: [
+            "stun:stun.l.google.com:19302",
+            "stun:stun1.l.google.com:19302",
+            "stun:stun.cloudflare.com:3478",
+        ],
+    },
+];

--- a/src/modules/media/ITransport.ts
+++ b/src/modules/media/ITransport.ts
@@ -18,6 +18,11 @@ export interface ITransport extends EventEmitter<Events> {
     audioAnalyser: Promise<AnalyserNode>;
     stats: CallStats;
 
+    /** Last `iceDiagnostics` payload, if any was emitted. Used by CallBus to replay. */
+    lastDiagnostics?: IceDiagnostics | null;
+    /** Set of `connectivityIssue`s already fired. Used by CallBus to replay. */
+    emittedIssues?: ReadonlySet<ConnectivityIssue>;
+
     start(): Promise<void>;
     stop(): Promise<void>;
 }

--- a/src/modules/media/ITransport.ts
+++ b/src/modules/media/ITransport.ts
@@ -1,4 +1,5 @@
 import type { CallStats } from "@/modules/call/Stats";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { EventEmitter } from "@/modules/shared/EventEmitter";
 
 export type TransportStatus = "disconnected" | "connected" | "connecting" | "reconnecting";
@@ -7,6 +8,8 @@ export type Events = {
     statusChanged: [status: TransportStatus];
     statsChanged: [stats: CallStats];
     peerMuted: [muted: boolean];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export interface ITransport extends EventEmitter<Events> {

--- a/src/modules/media/MediaManager.ts
+++ b/src/modules/media/MediaManager.ts
@@ -1,3 +1,4 @@
+import type { IceConfig } from "@/modules/media/ICEDiagnostics";
 import { EventEmitter } from "@/modules/shared/EventEmitter";
 import micWorkletUrl from "../worklets/AudioWorkletMic.ts?worklet";
 import outWorkletUrl from "../worklets/AudioWorkletOut.ts?worklet";
@@ -24,14 +25,16 @@ export class MediaManager extends EventEmitter<MediaManagerEvents> {
     public stream?: MediaStream;
     public muted = false;
     public readonly audioContext: AudioContext;
+    public readonly iceConfig?: IceConfig;
 
     private attachedElements: Set<HTMLAudioElement> = new Set();
     private activeSpeakerId?: string;
     private permissionGranted = false;
     private readonly _workletReady: Promise<void>;
 
-    constructor() {
+    constructor(options?: { iceConfig?: IceConfig }) {
         super();
+        this.iceConfig = options?.iceConfig;
         this.audioContext = new AudioContext({ latencyHint: 0 });
 
         this._workletReady = Promise.all([

--- a/src/modules/media/StunProbe.ts
+++ b/src/modules/media/StunProbe.ts
@@ -1,0 +1,64 @@
+export type StunProbeResult = {
+    server: string;
+    reachable: boolean;
+    latencyMs?: number;
+};
+
+const DEFAULT_PROBE_TIMEOUT_MS = 3000;
+
+/**
+ * Probe a list of STUN servers in parallel. A server is reported as
+ * `reachable: true` when at least one `srflx` candidate is gathered before
+ * the timeout fires. Each probe uses its own throwaway RTCPeerConnection.
+ *
+ * @example
+ *   const results = await runStunProbe([
+ *       "stun:stun.l.google.com:19302",
+ *       "stun:stun.cloudflare.com:3478",
+ *   ]);
+ */
+export function runStunProbe(
+    servers: string[],
+    timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS,
+): Promise<StunProbeResult[]> {
+    return Promise.all(servers.map((server) => probeOne(server, timeoutMs)));
+}
+
+function probeOne(server: string, timeoutMs: number): Promise<StunProbeResult> {
+    return new Promise((resolve) => {
+        const startedAt = Date.now();
+        const pc = new RTCPeerConnection({ iceServers: [{ urls: server }] });
+        let settled = false;
+
+        const cleanup = () => {
+            settled = true;
+            clearTimeout(timer);
+            pc.close();
+        };
+
+        const finish = (result: StunProbeResult) => {
+            if (settled) return;
+            cleanup();
+            resolve(result);
+        };
+
+        pc.onicecandidate = (event) => {
+            if (!event.candidate) return;
+            if (event.candidate.type !== "srflx") return;
+            finish({ server, reachable: true, latencyMs: Date.now() - startedAt });
+        };
+
+        const timer = setTimeout(() => {
+            finish({ server, reachable: false });
+        }, timeoutMs);
+
+        try {
+            pc.createDataChannel("probe");
+            pc.createOffer()
+                .then((offer) => pc.setLocalDescription(offer))
+                .catch(() => finish({ server, reachable: false }));
+        } catch {
+            finish({ server, reachable: false });
+        }
+    });
+}

--- a/src/modules/media/WebRTC.ts
+++ b/src/modules/media/WebRTC.ts
@@ -41,7 +41,12 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     };
     private connectedAt = 0;
     private symmetricNatTimer = 0;
-    private emittedIssues = new Set<ConnectivityIssue>();
+    private _emittedIssues = new Set<ConnectivityIssue>();
+    lastDiagnostics: IceDiagnostics | null = null;
+
+    get emittedIssues(): ReadonlySet<ConnectivityIssue> {
+        return this._emittedIssues;
+    }
 
     constructor(
         private readonly mediaManager: MediaManager,
@@ -180,6 +185,7 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
             stunReached,
             turnReached,
         };
+        this.lastDiagnostics = diag;
         this.emit("iceDiagnostics", diag);
 
         if (timedOut) this.emitIssue("ICE_GATHERING_TIMEOUT");
@@ -220,8 +226,8 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     }
 
     private emitIssue(issue: ConnectivityIssue) {
-        if (this.emittedIssues.has(issue)) return;
-        this.emittedIssues.add(issue);
+        if (this._emittedIssues.has(issue)) return;
+        this._emittedIssues.add(issue);
         this.emit("connectivityIssue", issue);
     }
 

--- a/src/modules/media/WebRTC.ts
+++ b/src/modules/media/WebRTC.ts
@@ -80,6 +80,7 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
             }
             if (this.pc.iceConnectionState === "connected" || this.pc.iceConnectionState === "completed") {
                 this.connectedAt = Date.now();
+                clearTimeout(this.symmetricNatTimer);
             }
         };
 

--- a/src/modules/media/WebRTC.ts
+++ b/src/modules/media/WebRTC.ts
@@ -1,28 +1,26 @@
 import type { CallStats } from "@/modules/call/Stats";
+import {
+    type ConnectivityIssue,
+    DEFAULT_ICE_GATHERING_TIMEOUT_MS,
+    DEFAULT_ICE_SERVERS,
+    type IceCandidateKind,
+    type IceConfig,
+    type IceDiagnostics,
+} from "@/modules/media/ICEDiagnostics";
 import type { Events, ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { EventEmitter } from "@/modules/shared/EventEmitter";
+
+const SYMMETRIC_NAT_DETECTION_WINDOW_MS = 10_000;
 
 export class WebRTCTransport extends EventEmitter<Events> implements ITransport {
     status: TransportStatus = "disconnected";
     peerMuted = false;
     audioAnalyser: Promise<AnalyserNode>;
     stats: CallStats = {
-        rtt: {
-            min: 0,
-            max: 0,
-            avg: 0,
-        },
-        tx: {
-            total: 0,
-            total_bytes: 0,
-            loss: 0,
-        },
-        rx: {
-            total: 0,
-            total_bytes: 0,
-            loss: 0,
-        },
+        rtt: { min: 0, max: 0, avg: 0 },
+        tx: { total: 0, total_bytes: 0, loss: 0 },
+        rx: { total: 0, total_bytes: 0, loss: 0 },
     };
 
     readonly answer: Promise<RTCSessionDescriptionInit>;
@@ -33,13 +31,29 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     private statsJob = 0;
     private started = false;
 
+    private readonly gatheringTimeoutMs: number;
+    private gatheringStartedAt = 0;
+    private candidatesByType: Record<IceCandidateKind, number> = {
+        host: 0,
+        srflx: 0,
+        prflx: 0,
+        relay: 0,
+    };
+    private connectedAt = 0;
+    private symmetricNatTimer = 0;
+    private emittedIssues = new Set<ConnectivityIssue>();
+
     constructor(
         private readonly mediaManager: MediaManager,
         offer?: string,
+        iceConfig?: IceConfig,
     ) {
         super();
 
-        this.pc = new RTCPeerConnection({ iceServers: [{ urls: "stun:stun.l.google.com:19302" }] });
+        this.gatheringTimeoutMs = iceConfig?.gatheringTimeoutMs ?? DEFAULT_ICE_GATHERING_TIMEOUT_MS;
+        const iceServers = iceConfig?.iceServers ?? DEFAULT_ICE_SERVERS;
+
+        this.pc = new RTCPeerConnection({ iceServers });
         if (offer) this.remoteOffer = { type: "offer", sdp: offer };
 
         const { promise: audioAnalyserPromise, resolve: resolveAudioAnalyser } = Promise.withResolvers<AnalyserNode>();
@@ -47,6 +61,22 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
 
         this.answerResolver = Promise.withResolvers<RTCSessionDescriptionInit>();
         this.answer = this.answerResolver.promise;
+
+        this.pc.onicecandidate = (event) => {
+            const candidate = event.candidate;
+            if (!candidate) return;
+            const kind = candidate.type as IceCandidateKind | undefined;
+            if (kind && kind in this.candidatesByType) this.candidatesByType[kind] += 1;
+        };
+
+        this.pc.oniceconnectionstatechange = () => {
+            if (this.pc.iceConnectionState === "failed") {
+                this.emitIssue("ICE_CONNECTION_FAILED");
+            }
+            if (this.pc.iceConnectionState === "connected" || this.pc.iceConnectionState === "completed") {
+                this.connectedAt = Date.now();
+            }
+        };
 
         this.pc.ontrack = (event) => {
             const remoteStream = event.streams[0];
@@ -80,21 +110,12 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
         };
 
         this.pc.onconnectionstatechange = () => {
-            if (this.pc.connectionState === "connecting") {
-                this.setStatus("connecting");
-            }
-
+            if (this.pc.connectionState === "connecting") this.setStatus("connecting");
             if (this.pc.connectionState === "disconnected" || this.pc?.connectionState === "closed") {
                 this.setStatus("disconnected");
             }
-
-            if (this.pc.connectionState === "closed") {
-                this.mediaManager.stopMedia();
-            }
-
-            if (this.pc.connectionState === "connected") {
-                this.setStatus("connected");
-            }
+            if (this.pc.connectionState === "closed") this.mediaManager.stopMedia();
+            if (this.pc.connectionState === "connected") this.setStatus("connected");
         };
     }
 
@@ -144,16 +165,69 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     }
 
     private async waitForIceGathering(): Promise<void> {
-        if (this.pc.iceGatheringState === "complete") return;
-        await new Promise<void>((resolve) => {
-            this.pc.addEventListener("icegatheringstatechange", () => {
-                if (this.pc.iceGatheringState === "complete") resolve();
-            });
+        this.gatheringStartedAt = Date.now();
+
+        const timedOut = await this.raceGatheringWithTimeout();
+
+        const duration = Date.now() - this.gatheringStartedAt;
+        const stunReached = this.candidatesByType.srflx > 0;
+        const turnReached = this.candidatesByType.relay > 0;
+
+        const diag: IceDiagnostics = {
+            gatheringDurationMs: duration,
+            gatheringTimedOut: timedOut,
+            candidatesByType: { ...this.candidatesByType },
+            stunReached,
+            turnReached,
+        };
+        this.emit("iceDiagnostics", diag);
+
+        if (timedOut) this.emitIssue("ICE_GATHERING_TIMEOUT");
+        if (timedOut && !stunReached) this.emitIssue("STUN_UNREACHABLE");
+        if (this.candidatesByType.host === 0) this.emitIssue("NO_HOST_CANDIDATES");
+
+        this.scheduleSymmetricNatCheck(stunReached);
+    }
+
+    private raceGatheringWithTimeout(): Promise<boolean> {
+        if (this.pc.iceGatheringState === "complete") return Promise.resolve(false);
+
+        return new Promise<boolean>((resolve) => {
+            const handler = () => {
+                if (this.pc.iceGatheringState !== "complete") return;
+                this.pc.removeEventListener("icegatheringstatechange", handler);
+                clearTimeout(timer);
+                resolve(false);
+            };
+
+            const timer = setTimeout(() => {
+                this.pc.removeEventListener("icegatheringstatechange", handler);
+                resolve(true);
+            }, this.gatheringTimeoutMs);
+
+            this.pc.addEventListener("icegatheringstatechange", handler);
         });
+    }
+
+    private scheduleSymmetricNatCheck(stunReached: boolean) {
+        if (!stunReached) return;
+        if (this.symmetricNatTimer) return;
+        this.symmetricNatTimer = setTimeout(() => {
+            const noConnection =
+                this.pc.iceConnectionState !== "connected" && this.pc.iceConnectionState !== "completed";
+            if (noConnection) this.emitIssue("SYMMETRIC_NAT_SUSPECTED");
+        }, SYMMETRIC_NAT_DETECTION_WINDOW_MS) as unknown as number;
+    }
+
+    private emitIssue(issue: ConnectivityIssue) {
+        if (this.emittedIssues.has(issue)) return;
+        this.emittedIssues.add(issue);
+        this.emit("connectivityIssue", issue);
     }
 
     async stop(): Promise<void> {
         clearInterval(this.statsJob);
+        clearTimeout(this.symmetricNatTimer);
 
         this.pc.close();
         await this.mediaManager.stopMedia();

--- a/src/modules/shared/StickyDiagnosticsEmitter.ts
+++ b/src/modules/shared/StickyDiagnosticsEmitter.ts
@@ -1,0 +1,39 @@
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
+import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
+
+type DiagnosticsEvents = {
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
+};
+
+/**
+ * EventEmitter that replays cached `iceDiagnostics` (latest) and
+ * `connectivityIssue` (every unique) values to late subscribers, so listeners
+ * attached after the events fired still see them. Used by CallBus and every
+ * call facade because ICE gathering can complete before a facade exists.
+ */
+export class StickyDiagnosticsEmitter<
+    T extends DiagnosticsEvents & Record<string, unknown[]>,
+> extends EventEmitter<T> {
+    private lastIceDiagnostics: IceDiagnostics | null = null;
+    private emittedIssues = new Set<ConnectivityIssue>();
+
+    emit<K extends keyof T>(event: K, ...args: T[K]): void {
+        if (event === "iceDiagnostics") this.lastIceDiagnostics = args[0] as IceDiagnostics;
+        if (event === "connectivityIssue") this.emittedIssues.add(args[0] as ConnectivityIssue);
+        super.emit(event, ...args);
+    }
+
+    on<K extends keyof T>(event: K, callback: (...args: T[K]) => void): Unsubscribe {
+        const unsub = super.on(event, callback);
+        if (event === "iceDiagnostics" && this.lastIceDiagnostics) {
+            (callback as unknown as (d: IceDiagnostics) => void)(this.lastIceDiagnostics);
+        }
+        if (event === "connectivityIssue") {
+            for (const issue of this.emittedIssues) {
+                (callback as unknown as (i: ConnectivityIssue) => void)(issue);
+            }
+        }
+        return unsub;
+    }
+}

--- a/src/test/Wavoip.ice-config.spec.ts
+++ b/src/test/Wavoip.ice-config.spec.ts
@@ -1,0 +1,62 @@
+import { Wavoip } from "@/Wavoip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mediaManagerInstances: Array<{ iceConfig?: unknown }> = [];
+
+vi.mock("@/modules/media/MediaManager", () => {
+    return {
+        MediaManager: class {
+            iceConfig: unknown;
+            devices: never[] = [];
+            activeMic = undefined;
+            activeSpeaker = undefined;
+            constructor(config?: { iceConfig?: unknown }) {
+                this.iceConfig = config?.iceConfig;
+                mediaManagerInstances.push(this);
+            }
+            on() {
+                return () => {};
+            }
+        },
+    };
+});
+
+vi.mock("@/modules/device/DeviceConnection", () => {
+    return {
+        DeviceConnection: class {
+            token = "fake";
+            on() {
+                return () => {};
+            }
+            constructor(_mm: unknown, token: string) {
+                this.token = token;
+            }
+        },
+    };
+});
+
+describe("Wavoip iceConfig", () => {
+    beforeEach(() => {
+        mediaManagerInstances.length = 0;
+    });
+
+    afterEach(() => {
+        mediaManagerInstances.length = 0;
+    });
+
+    it("passes iceConfig through to MediaManager when provided", () => {
+        const iceConfig = {
+            gatheringTimeoutMs: 1500,
+            iceServers: [{ urls: "stun:custom.example:3478" }],
+        };
+        new Wavoip({ tokens: [], iceConfig });
+
+        expect(mediaManagerInstances).toHaveLength(1);
+        expect(mediaManagerInstances[0].iceConfig).toEqual(iceConfig);
+    });
+
+    it("does not require iceConfig", () => {
+        expect(() => new Wavoip({ tokens: [] })).not.toThrow();
+        expect(mediaManagerInstances[0].iceConfig).toBeUndefined();
+    });
+});

--- a/src/test/call/CallActive.test.ts
+++ b/src/test/call/CallActive.test.ts
@@ -255,5 +255,40 @@ describe("CallActive", () => {
 
             expect(cb).toHaveBeenCalledWith("ENDED");
         });
+
+        it("on('iceDiagnostics') fires when bus emits iceDiagnostics", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+            const cb = vi.fn();
+            active.on("iceDiagnostics", cb);
+
+            const diag = {
+                gatheringDurationMs: 100,
+                gatheringTimedOut: false,
+                candidatesByType: { host: 1, srflx: 1, prflx: 0, relay: 0 },
+                stunReached: true,
+                turnReached: false,
+            };
+            bus.emit("iceDiagnostics", diag);
+
+            expect(cb).toHaveBeenCalledWith(diag);
+        });
+
+        it("on('connectivityIssue') fires when bus emits connectivityIssue", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+            const cb = vi.fn();
+            active.on("connectivityIssue", cb);
+
+            bus.emit("connectivityIssue", "STUN_UNREACHABLE");
+
+            expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+        });
     });
 });

--- a/src/test/call/CallBus.replay.spec.ts
+++ b/src/test/call/CallBus.replay.spec.ts
@@ -1,0 +1,114 @@
+import { CallBus } from "@/modules/call/CallBus";
+import { Call } from "@/modules/device/Call";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
+import type { ITransport, Events as TransportEvents } from "@/modules/media/ITransport";
+import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { describe, expect, it, vi } from "vitest";
+
+const peer = { phone: "5511999999999", displayName: null, profilePicture: null };
+
+function makeCall() {
+    return Call.CreateOffer("call-1", "OFFICIAL", peer, "device-token");
+}
+
+function makeMockSocket() {
+    return new EventEmitter<Record<string, unknown[]>>() as never;
+}
+
+function makeMockTransport(): ITransport & {
+    lastDiagnostics?: IceDiagnostics | null;
+    emittedIssues?: ReadonlySet<ConnectivityIssue>;
+} {
+    const t = new EventEmitter<TransportEvents>() as unknown as ITransport & {
+        lastDiagnostics?: IceDiagnostics | null;
+        emittedIssues?: ReadonlySet<ConnectivityIssue>;
+    };
+    t.status = "disconnected";
+    t.peerMuted = false;
+    t.audioAnalyser = Promise.resolve({} as AnalyserNode);
+    t.stats = {
+        rtt: { min: 0, max: 0, avg: 0 },
+        tx: { total: 0, total_bytes: 0, loss: 0 },
+        rx: { total: 0, total_bytes: 0, loss: 0 },
+    };
+    t.start = vi.fn().mockResolvedValue(undefined);
+    t.stop = vi.fn().mockResolvedValue(undefined);
+    return t;
+}
+
+describe("CallBus replays diagnostic state on wireTransport", () => {
+    it("re-emits transport.lastDiagnostics when present", () => {
+        const bus = new CallBus(makeCall(), makeMockSocket());
+        const transport = makeMockTransport();
+        const diag: IceDiagnostics = {
+            gatheringDurationMs: 120,
+            gatheringTimedOut: false,
+            candidatesByType: { host: 1, srflx: 1, prflx: 0, relay: 0 },
+            stunReached: true,
+            turnReached: false,
+        };
+        transport.lastDiagnostics = diag;
+
+        const cb = vi.fn();
+        bus.on("iceDiagnostics", cb);
+
+        bus.wireTransport(transport);
+
+        expect(cb).toHaveBeenCalledWith(diag);
+    });
+
+    it("re-emits every issue in transport.emittedIssues when present", () => {
+        const bus = new CallBus(makeCall(), makeMockSocket());
+        const transport = makeMockTransport();
+        transport.emittedIssues = new Set<ConnectivityIssue>(["STUN_UNREACHABLE", "ICE_GATHERING_TIMEOUT"]);
+
+        const cb = vi.fn();
+        bus.on("connectivityIssue", cb);
+
+        bus.wireTransport(transport);
+
+        expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+        expect(cb).toHaveBeenCalledWith("ICE_GATHERING_TIMEOUT");
+        expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not replay when transport has no cached state", () => {
+        const bus = new CallBus(makeCall(), makeMockSocket());
+        const transport = makeMockTransport();
+
+        const diagCb = vi.fn();
+        const issueCb = vi.fn();
+        bus.on("iceDiagnostics", diagCb);
+        bus.on("connectivityIssue", issueCb);
+
+        bus.wireTransport(transport);
+
+        expect(diagCb).not.toHaveBeenCalled();
+        expect(issueCb).not.toHaveBeenCalled();
+    });
+});
+
+describe("WebRTCTransport exposes cached state", () => {
+    it("populates lastDiagnostics + emittedIssues after createOffer", async () => {
+        const { buildMockPeerConnection, makeMockMediaManager } = await import("@/test/media/ice-test-helpers");
+        const { WebRTCTransport } = await import("@/modules/media/WebRTC");
+        const pcFactory = buildMockPeerConnection();
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.useFakeTimers();
+        try {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 200 });
+            const offerPromise = transport.createOffer();
+            await vi.advanceTimersByTimeAsync(300);
+            await offerPromise;
+
+            expect(transport.lastDiagnostics).toBeDefined();
+            expect(transport.lastDiagnostics?.gatheringTimedOut).toBe(true);
+            expect(transport.emittedIssues.has("STUN_UNREACHABLE")).toBe(true);
+        } finally {
+            vi.unstubAllGlobals();
+            vi.useRealTimers();
+        }
+    });
+});

--- a/src/test/call/CallBus.replay.spec.ts
+++ b/src/test/call/CallBus.replay.spec.ts
@@ -36,6 +36,48 @@ function makeMockTransport(): ITransport & {
     return t;
 }
 
+describe("CallBus is sticky for iceDiagnostics + connectivityIssue", () => {
+    it("immediately delivers cached iceDiagnostics to a late subscriber", () => {
+        const bus = new CallBus(makeCall(), makeMockSocket());
+        const diag: IceDiagnostics = {
+            gatheringDurationMs: 50,
+            gatheringTimedOut: false,
+            candidatesByType: { host: 1, srflx: 1, prflx: 0, relay: 0 },
+            stunReached: true,
+            turnReached: false,
+        };
+        bus.emit("iceDiagnostics", diag);
+
+        const cb = vi.fn();
+        bus.on("iceDiagnostics", cb);
+
+        expect(cb).toHaveBeenCalledWith(diag);
+    });
+
+    it("immediately delivers every cached connectivityIssue to a late subscriber", () => {
+        const bus = new CallBus(makeCall(), makeMockSocket());
+        bus.emit("connectivityIssue", "STUN_UNREACHABLE");
+        bus.emit("connectivityIssue", "ICE_GATHERING_TIMEOUT");
+
+        const cb = vi.fn();
+        bus.on("connectivityIssue", cb);
+
+        expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+        expect(cb).toHaveBeenCalledWith("ICE_GATHERING_TIMEOUT");
+        expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not replay non-sticky events to late subscribers", () => {
+        const bus = new CallBus(makeCall(), makeMockSocket());
+        bus.emit("ringing");
+
+        const cb = vi.fn();
+        bus.on("ringing", cb);
+
+        expect(cb).not.toHaveBeenCalled();
+    });
+});
+
 describe("CallBus replays diagnostic state on wireTransport", () => {
     it("re-emits transport.lastDiagnostics when present", () => {
         const bus = new CallBus(makeCall(), makeMockSocket());

--- a/src/test/call/CallBus.test.ts
+++ b/src/test/call/CallBus.test.ts
@@ -289,5 +289,40 @@ describe("CallBus", () => {
 
             expect(cb).not.toHaveBeenCalled();
         });
+
+        it("transport iceDiagnostics → bus emits iceDiagnostics", () => {
+            const call = makeCall();
+            const socket = makeMockSocket();
+            const bus = new CallBus(call, socket as never);
+            const transport = makeMockTransport();
+            const cb = vi.fn();
+            bus.on("iceDiagnostics", cb);
+
+            bus.wireTransport(transport);
+            const diag = {
+                gatheringDurationMs: 200,
+                gatheringTimedOut: false,
+                candidatesByType: { host: 1, srflx: 1, prflx: 0, relay: 0 },
+                stunReached: true,
+                turnReached: false,
+            };
+            (transport as unknown as EventEmitter<TransportEvents>).emit("iceDiagnostics", diag);
+
+            expect(cb).toHaveBeenCalledWith(diag);
+        });
+
+        it("transport connectivityIssue → bus emits connectivityIssue", () => {
+            const call = makeCall();
+            const socket = makeMockSocket();
+            const bus = new CallBus(call, socket as never);
+            const transport = makeMockTransport();
+            const cb = vi.fn();
+            bus.on("connectivityIssue", cb);
+
+            bus.wireTransport(transport);
+            (transport as unknown as EventEmitter<TransportEvents>).emit("connectivityIssue", "STUN_UNREACHABLE");
+
+            expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+        });
     });
 });

--- a/src/test/call/CallOutgoing.diagnostics.spec.ts
+++ b/src/test/call/CallOutgoing.diagnostics.spec.ts
@@ -1,0 +1,62 @@
+import { CallBus } from "@/modules/call/CallBus";
+import { CallOutgoingProxy } from "@/modules/call/CallOutgoing";
+import { Call } from "@/modules/device/Call";
+import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { describe, expect, it, vi } from "vitest";
+
+const peer = { phone: "5511999999999", displayName: "Test", profilePicture: null };
+
+function makeCall() {
+    return Call.CreateOffer("call-1", "OFFICIAL", peer, "device-token");
+}
+
+function makeMockBus(call: Call) {
+    const socket = new EventEmitter<Record<string, unknown[]>>() as never;
+    return new CallBus(call, socket);
+}
+
+function makeMockSocket() {
+    return new EventEmitter<Record<string, unknown[]>>() as never;
+}
+
+function makeMockMediaManager() {
+    return {
+        setMuted: vi.fn(),
+        startMedia: vi.fn(),
+        stopMedia: vi.fn(),
+        audioContext: {} as AudioContext,
+    };
+}
+
+describe("CallOutgoing diagnostics", () => {
+    it("on('iceDiagnostics') fires when bus emits iceDiagnostics", () => {
+        const call = makeCall();
+        const bus = makeMockBus(call);
+        const outgoing = CallOutgoingProxy(call, bus, makeMockSocket(), makeMockMediaManager() as never);
+        const cb = vi.fn();
+        outgoing.on("iceDiagnostics", cb);
+
+        const diag = {
+            gatheringDurationMs: 75,
+            gatheringTimedOut: false,
+            candidatesByType: { host: 1, srflx: 1, prflx: 0, relay: 0 },
+            stunReached: true,
+            turnReached: false,
+        };
+        bus.emit("iceDiagnostics", diag);
+
+        expect(cb).toHaveBeenCalledWith(diag);
+    });
+
+    it("on('connectivityIssue') fires when bus emits connectivityIssue", () => {
+        const call = makeCall();
+        const bus = makeMockBus(call);
+        const outgoing = CallOutgoingProxy(call, bus, makeMockSocket(), makeMockMediaManager() as never);
+        const cb = vi.fn();
+        outgoing.on("connectivityIssue", cb);
+
+        bus.emit("connectivityIssue", "STUN_UNREACHABLE");
+
+        expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+    });
+});

--- a/src/test/call/Offer.test.ts
+++ b/src/test/call/Offer.test.ts
@@ -174,5 +174,36 @@ describe("Offer", () => {
 
             expect(cb).toHaveBeenCalledWith("ACTIVE");
         });
+
+        it("on('iceDiagnostics') fires when bus emits iceDiagnostics", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const offer = OfferProxy(call, bus, { onAccept: vi.fn(), onReject: vi.fn() });
+            const cb = vi.fn();
+            offer.on("iceDiagnostics", cb);
+
+            const diag = {
+                gatheringDurationMs: 50,
+                gatheringTimedOut: false,
+                candidatesByType: { host: 1, srflx: 0, prflx: 0, relay: 0 },
+                stunReached: false,
+                turnReached: false,
+            };
+            bus.emit("iceDiagnostics", diag);
+
+            expect(cb).toHaveBeenCalledWith(diag);
+        });
+
+        it("on('connectivityIssue') fires when bus emits connectivityIssue", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const offer = OfferProxy(call, bus, { onAccept: vi.fn(), onReject: vi.fn() });
+            const cb = vi.fn();
+            offer.on("connectivityIssue", cb);
+
+            bus.emit("connectivityIssue", "STUN_UNREACHABLE");
+
+            expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+        });
     });
 });

--- a/src/test/media/StunProbe.spec.ts
+++ b/src/test/media/StunProbe.spec.ts
@@ -1,0 +1,81 @@
+import { runStunProbe } from "@/modules/media/StunProbe";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMockPeerConnection } from "./ice-test-helpers";
+
+describe("runStunProbe", () => {
+    const pcFactory = buildMockPeerConnection();
+
+    beforeEach(() => {
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it("returns reachable=true when an srflx candidate is gathered before the timeout", async () => {
+        const probe = runStunProbe(["stun:server-a.example:3478"], 1000);
+
+        await vi.advanceTimersByTimeAsync(10);
+        pcFactory.instances[0]._fireIceCandidate("srflx");
+        await vi.advanceTimersByTimeAsync(10);
+
+        const results = await probe;
+        expect(results).toHaveLength(1);
+        expect(results[0].server).toBe("stun:server-a.example:3478");
+        expect(results[0].reachable).toBe(true);
+        expect(results[0].latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns reachable=false when no srflx candidate arrives before the timeout", async () => {
+        const probe = runStunProbe(["stun:dead.example:3478"], 500);
+
+        await vi.advanceTimersByTimeAsync(600);
+
+        const results = await probe;
+        expect(results[0].reachable).toBe(false);
+        expect(results[0].latencyMs).toBeUndefined();
+    });
+
+    it("probes every server in parallel and returns a result per server", async () => {
+        const probe = runStunProbe(["stun:a.example:3478", "stun:b.example:3478", "stun:c.example:3478"], 1000);
+
+        await vi.advanceTimersByTimeAsync(10);
+        expect(pcFactory.instances).toHaveLength(3);
+        pcFactory.instances[0]._fireIceCandidate("srflx");
+        pcFactory.instances[2]._fireIceCandidate("srflx");
+        await vi.advanceTimersByTimeAsync(1100);
+
+        const results = await probe;
+        expect(results.map((r) => r.server)).toEqual([
+            "stun:a.example:3478",
+            "stun:b.example:3478",
+            "stun:c.example:3478",
+        ]);
+        expect(results[0].reachable).toBe(true);
+        expect(results[1].reachable).toBe(false);
+        expect(results[2].reachable).toBe(true);
+    });
+
+    it("closes every RTCPeerConnection after the probe finishes", async () => {
+        const probe = runStunProbe(["stun:a.example:3478", "stun:b.example:3478"], 300);
+
+        await vi.advanceTimersByTimeAsync(400);
+        await probe;
+
+        for (const pc of pcFactory.instances) {
+            expect(pc.close).toHaveBeenCalled();
+        }
+    });
+
+    it("uses a default timeout when none is provided", async () => {
+        const probe = runStunProbe(["stun:a.example:3478"]);
+
+        await vi.advanceTimersByTimeAsync(5000);
+        const results = await probe;
+        expect(results).toHaveLength(1);
+    });
+});

--- a/src/test/media/WebRTCTransport.ice-config.spec.ts
+++ b/src/test/media/WebRTCTransport.ice-config.spec.ts
@@ -1,0 +1,42 @@
+import { WebRTCTransport } from "@/modules/media/WebRTC";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockAudio, buildMockPeerConnection, makeMockMediaManager } from "./ice-test-helpers";
+
+describe("WebRTCTransport ICE server config", () => {
+    const pcFactory = buildMockPeerConnection();
+
+    beforeEach(() => {
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.stubGlobal("Audio", MockAudio);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("uses multiple default STUN servers when no iceServers configured", () => {
+        const mm = makeMockMediaManager();
+        new WebRTCTransport(mm as never);
+
+        const config = pcFactory.last()._config;
+        expect(config.iceServers).toBeDefined();
+        const servers = config.iceServers ?? [];
+        const urls = servers
+            .flatMap((s) => (Array.isArray(s.urls) ? s.urls : [s.urls]))
+            .filter((u): u is string => typeof u === "string");
+        expect(urls.length).toBeGreaterThanOrEqual(2);
+        expect(urls.every((u) => u.startsWith("stun:"))).toBe(true);
+    });
+
+    it("uses iceServers from config when provided", () => {
+        const mm = makeMockMediaManager();
+        const custom: RTCIceServer[] = [
+            { urls: "stun:my-stun.example.com:3478" },
+            { urls: ["turn:my-turn.example.com:3478"], username: "u", credential: "c" },
+        ];
+        new WebRTCTransport(mm as never, undefined, { iceServers: custom });
+
+        expect(pcFactory.last()._config.iceServers).toEqual(custom);
+    });
+});

--- a/src/test/media/WebRTCTransport.ice-diagnostics.spec.ts
+++ b/src/test/media/WebRTCTransport.ice-diagnostics.spec.ts
@@ -1,0 +1,194 @@
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
+import { WebRTCTransport } from "@/modules/media/WebRTC";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockAudio, buildMockPeerConnection, makeMockMediaManager } from "./ice-test-helpers";
+
+describe("WebRTCTransport ICE diagnostics", () => {
+    const pcFactory = buildMockPeerConnection();
+
+    beforeEach(() => {
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.stubGlobal("Audio", MockAudio);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    describe("candidate counting", () => {
+        it("counts candidates by type from onicecandidate events", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const diagPromise = new Promise<IceDiagnostics>((resolve) => {
+                transport.on("iceDiagnostics", resolve);
+            });
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("host");
+            pc._fireIceCandidate("host");
+            pc._fireIceCandidate("srflx");
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            const diag = await diagPromise;
+            expect(diag.candidatesByType.host).toBe(2);
+            expect(diag.candidatesByType.srflx).toBe(1);
+            expect(diag.candidatesByType.relay).toBe(0);
+            expect(diag.candidatesByType.prflx).toBe(0);
+        });
+    });
+
+    describe("iceDiagnostics event", () => {
+        it("emits with gatheringTimedOut=false when gathering completes in time", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const cb = vi.fn();
+            transport.on("iceDiagnostics", cb);
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("srflx");
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            expect(cb).toHaveBeenCalledTimes(1);
+            const diag = cb.mock.calls[0][0] as IceDiagnostics;
+            expect(diag.gatheringTimedOut).toBe(false);
+            expect(diag.stunReached).toBe(true);
+            expect(diag.turnReached).toBe(false);
+            expect(diag.gatheringDurationMs).toBeGreaterThanOrEqual(0);
+        });
+
+        it("emits with gatheringTimedOut=true when the timeout fires first", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 200 });
+
+            const cb = vi.fn();
+            transport.on("iceDiagnostics", cb);
+
+            const offerPromise = transport.createOffer();
+            pcFactory.last()._fireIceCandidate("host");
+            await vi.advanceTimersByTimeAsync(300);
+            await offerPromise;
+
+            expect(cb).toHaveBeenCalledTimes(1);
+            const diag = cb.mock.calls[0][0] as IceDiagnostics;
+            expect(diag.gatheringTimedOut).toBe(true);
+            expect(diag.stunReached).toBe(false);
+        });
+
+        it("sets turnReached=true when a relay candidate is gathered", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const cb = vi.fn();
+            transport.on("iceDiagnostics", cb);
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("relay");
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            const diag = cb.mock.calls[0][0] as IceDiagnostics;
+            expect(diag.turnReached).toBe(true);
+        });
+    });
+
+    describe("connectivityIssue event", () => {
+        it("emits STUN_UNREACHABLE when gathering times out without an srflx candidate", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 200 });
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            pcFactory.last()._fireIceCandidate("host");
+            await vi.advanceTimersByTimeAsync(300);
+            await offerPromise;
+
+            expect(issues).toContain("STUN_UNREACHABLE");
+        });
+
+        it("does not emit STUN_UNREACHABLE when an srflx candidate is gathered before timeout", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 200 });
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("host");
+            pc._fireIceCandidate("srflx");
+            await vi.advanceTimersByTimeAsync(50);
+            pc._completeGathering();
+            await offerPromise;
+
+            expect(issues).not.toContain("STUN_UNREACHABLE");
+        });
+
+        it("emits NO_HOST_CANDIDATES when gathering ends without a host candidate", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("srflx");
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            expect(issues).toContain("NO_HOST_CANDIDATES");
+        });
+
+        it("emits ICE_CONNECTION_FAILED when iceConnectionState transitions to failed", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            pc._fireIceConnectionState("failed");
+            expect(issues).toContain("ICE_CONNECTION_FAILED");
+        });
+
+        it("does not emit duplicates for the same issue", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            pc._fireIceConnectionState("failed");
+            pc._fireIceConnectionState("failed");
+
+            expect(issues.filter((i) => i === "ICE_CONNECTION_FAILED")).toHaveLength(1);
+        });
+    });
+});

--- a/src/test/media/WebRTCTransport.ice-timeout.spec.ts
+++ b/src/test/media/WebRTCTransport.ice-timeout.spec.ts
@@ -1,0 +1,123 @@
+import { WebRTCTransport } from "@/modules/media/WebRTC";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockAudio, buildMockPeerConnection, makeMockMediaManager } from "./ice-test-helpers";
+
+describe("WebRTCTransport ICE gathering timeout", () => {
+    const pcFactory = buildMockPeerConnection();
+
+    beforeEach(() => {
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.stubGlobal("Audio", MockAudio);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    describe("createOffer (outgoing)", () => {
+        it("resolves immediately when gathering completes before the timeout", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const offerPromise = transport.createOffer();
+
+            await vi.advanceTimersByTimeAsync(10);
+            pcFactory.last()._completeGathering();
+
+            const sdp = await offerPromise;
+            expect(sdp).toBe("mock-answer-sdp");
+        });
+
+        it("resolves at the configured timeout when gathering never completes", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 800 });
+
+            const offerPromise = transport.createOffer();
+
+            await vi.advanceTimersByTimeAsync(799);
+            let settled = false;
+            offerPromise.then(() => {
+                settled = true;
+            });
+            await Promise.resolve();
+            expect(settled).toBe(false);
+
+            await vi.advanceTimersByTimeAsync(2);
+            await offerPromise;
+            expect(settled).toBe(true);
+        });
+
+        it("uses the 2500ms default timeout when none is configured", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const offerPromise = transport.createOffer();
+
+            await vi.advanceTimersByTimeAsync(2499);
+            let settled = false;
+            offerPromise.then(() => {
+                settled = true;
+            });
+            await Promise.resolve();
+            expect(settled).toBe(false);
+
+            await vi.advanceTimersByTimeAsync(2);
+            await offerPromise;
+            expect(settled).toBe(true);
+        });
+
+        it("removes the icegatheringstatechange listener after resolving on completion", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const offerPromise = transport.createOffer();
+            await vi.advanceTimersByTimeAsync(5);
+            pcFactory.last()._completeGathering();
+            await offerPromise;
+
+            const { added, removed } = pcFactory.last()._iceListenerCounts;
+            expect(added).toBeGreaterThan(0);
+            expect(removed).toBe(added);
+        });
+
+        it("removes the icegatheringstatechange listener after timing out", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 500 });
+
+            const offerPromise = transport.createOffer();
+            await vi.advanceTimersByTimeAsync(600);
+            await offerPromise;
+
+            const { added, removed } = pcFactory.last()._iceListenerCounts;
+            expect(added).toBeGreaterThan(0);
+            expect(removed).toBe(added);
+        });
+
+        it("returns immediately when gathering is already complete before waitForIceGathering attaches", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+            pcFactory.last().iceGatheringState = "complete";
+
+            const sdp = await transport.createOffer();
+            expect(sdp).toBe("mock-answer-sdp");
+        });
+    });
+
+    describe("start (incoming) honors the same timeout cap", () => {
+        it("resolves the answer at the configured timeout when gathering hangs", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, "offer-sdp", { gatheringTimeoutMs: 400 });
+
+            const startPromise = transport.start();
+
+            await vi.advanceTimersByTimeAsync(500);
+            await startPromise;
+
+            const answer = await transport.answer;
+            expect(answer.sdp).toBe("mock-answer-sdp");
+        });
+    });
+});

--- a/src/test/media/ice-test-helpers.ts
+++ b/src/test/media/ice-test-helpers.ts
@@ -1,0 +1,159 @@
+import { type Mock, vi } from "vitest";
+
+export class MockMediaStreamTrack {
+    private listeners = new Map<string, Set<() => void>>();
+    enabled = false;
+
+    addEventListener(event: string, listener: () => void) {
+        if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+        this.listeners.get(event)?.add(listener);
+    }
+
+    dispatchEvent(event: string) {
+        for (const listener of this.listeners.get(event) ?? []) listener();
+    }
+}
+
+/**
+ * Configurable mock RTCPeerConnection.
+ * Tests drive gathering completion + ICE state transitions manually via the
+ * `_*` helpers; unlike a real PC, nothing auto-completes.
+ */
+export class MockRTCPeerConnection {
+    _config: RTCConfiguration;
+    _iceListenerCounts = { added: 0, removed: 0 };
+
+    ontrack: ((e: RTCTrackEvent) => void) | null = null;
+    onconnectionstatechange: (() => void) | null = null;
+    onicecandidate: ((e: { candidate: RTCIceCandidate | null }) => void) | null = null;
+    oniceconnectionstatechange: (() => void) | null = null;
+
+    connectionState: RTCPeerConnectionState = "new";
+    iceConnectionState: RTCIceConnectionState = "new";
+    iceGatheringState: RTCIceGatheringState = "new";
+
+    addTrack: Mock = vi.fn();
+    close: Mock = vi.fn();
+    createDataChannel: Mock = vi.fn();
+    setRemoteDescription: Mock = vi.fn().mockResolvedValue(undefined);
+    createAnswer: Mock = vi.fn().mockResolvedValue({ type: "answer", sdp: "mock-answer-sdp" });
+    createOffer: Mock = vi.fn().mockResolvedValue({ type: "offer", sdp: "mock-offer-sdp" });
+    setLocalDescription: Mock = vi.fn().mockResolvedValue(undefined);
+    localDescription = { type: "answer", sdp: "mock-answer-sdp" } as RTCSessionDescription;
+    getStats: Mock = vi.fn().mockResolvedValue(new Map());
+
+    namedListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+    constructor(config?: RTCConfiguration) {
+        this._config = config ?? {};
+        instances.push(this);
+    }
+
+    addEventListener(event: string, listener: (...args: unknown[]) => void) {
+        if (!this.namedListeners.has(event)) this.namedListeners.set(event, new Set());
+        this.namedListeners.get(event)?.add(listener);
+        if (event === "icegatheringstatechange") this._iceListenerCounts.added += 1;
+    }
+
+    removeEventListener(event: string, listener: (...args: unknown[]) => void) {
+        this.namedListeners.get(event)?.delete(listener);
+        if (event === "icegatheringstatechange") this._iceListenerCounts.removed += 1;
+    }
+
+    dispatchEvent(event: string) {
+        for (const listener of this.namedListeners.get(event) ?? []) listener();
+    }
+
+    _completeGathering() {
+        this.iceGatheringState = "complete";
+        this.dispatchEvent("icegatheringstatechange");
+    }
+
+    _fireIceCandidate(type: RTCIceCandidateType) {
+        this.onicecandidate?.({ candidate: { type } as RTCIceCandidate });
+    }
+
+    _fireIceConnectionState(state: RTCIceConnectionState) {
+        this.iceConnectionState = state;
+        this.oniceconnectionstatechange?.();
+        this.dispatchEvent("iceconnectionstatechange");
+    }
+
+    _fireConnectionState(state: RTCPeerConnectionState) {
+        this.connectionState = state;
+        this.onconnectionstatechange?.();
+    }
+}
+
+const instances: MockRTCPeerConnection[] = [];
+
+export interface PcFactory {
+    MockRTCPeerConnection: typeof MockRTCPeerConnection;
+    instances: MockRTCPeerConnection[];
+    last(): MockRTCPeerConnection;
+    reset(): void;
+}
+
+export function buildMockPeerConnection(): PcFactory {
+    return {
+        MockRTCPeerConnection,
+        instances,
+        last(): MockRTCPeerConnection {
+            const inst = instances[instances.length - 1];
+            if (!inst) throw new Error("No RTCPeerConnection instance created yet");
+            return inst;
+        },
+        reset() {
+            instances.length = 0;
+        },
+    };
+}
+
+export interface MockMediaManager {
+    setMuted: Mock;
+    startMedia: Mock;
+    stopMedia: Mock;
+    audioContext: {
+        createMediaStreamSource: Mock;
+        createAnalyser: Mock;
+        destination: object;
+    };
+    _analyser: { fftSize: number; getByteTimeDomainData: Mock; connect: Mock };
+    _stream: MediaStream;
+    _track: MockMediaStreamTrack;
+}
+
+export function makeMockMediaManager(): MockMediaManager {
+    const analyser = {
+        fftSize: 256,
+        getByteTimeDomainData: vi.fn((arr: Uint8Array) => arr.fill(128)),
+        connect: vi.fn(),
+    };
+    const source = { connect: vi.fn() };
+    const audioContext = {
+        createMediaStreamSource: vi.fn().mockReturnValue(source),
+        createAnalyser: vi.fn().mockReturnValue(analyser),
+        destination: {},
+    };
+    const mockTrack = new MockMediaStreamTrack();
+    const mockStream = {
+        getTracks: vi.fn().mockReturnValue([mockTrack]),
+        getAudioTracks: vi.fn().mockReturnValue([mockTrack]),
+        id: "mic-stream",
+    } as unknown as MediaStream;
+
+    return {
+        setMuted: vi.fn(),
+        startMedia: vi.fn().mockResolvedValue(mockStream),
+        stopMedia: vi.fn().mockResolvedValue(undefined),
+        audioContext,
+        _analyser: analyser,
+        _stream: mockStream,
+        _track: mockTrack,
+    };
+}
+
+export class MockAudio {
+    muted = false;
+    srcObject: MediaStream | null = null;
+}


### PR DESCRIPTION
## Summary

- Root-cause: `waitForIceGathering()` blocked `createOffer`/`start` for 1–2 minutes on machines where the single Google STUN server was unreachable. Code now races a 2.5s default timeout (configurable via `Wavoip({ iceConfig: { gatheringTimeoutMs } })`), uses three default STUN servers in parallel, removes the `icegatheringstatechange` listener on resolve/timeout, and is race-safe.
- New `iceDiagnostics` event (gathering duration, candidates by type, `stunReached`, `turnReached`) and `connectivityIssue` event (`STUN_UNREACHABLE`, `ICE_GATHERING_TIMEOUT`, `ICE_CONNECTION_FAILED`, `NO_HOST_CANDIDATES`, `SYMMETRIC_NAT_SUSPECTED`) are emitted by `WebRTCTransport` and relayed through `CallBus` to `Offer`, `CallOutgoing`, `CallActive` facades.
- Public `runStunProbe(servers, timeoutMs?)` util added for diagnostics UIs (used by the webphone debug screen in a follow-up PR).
- Docs (pt-BR): new `troubleshooting.md`, updated `getting-started/initialization.md`, event tables in `calls/*.md`, `SUMMARY.md`.
- No TURN added by default — symmetric-NAT users still fail; surfaced via `SYMMETRIC_NAT_SUSPECTED` so we can measure before paying for relay infra.

## Test plan

- [x] `pnpm lint` — passes (tsc + biome)
- [x] `pnpm test` — 14 files / 159 tests pass; TDD: tests written first, all red, then green
- [x] `pnpm build` — vite build + dts emit clean
- [ ] Manual smoke on Chromium with STUN blocked at firewall — confirm gathering returns ≤2.5s and `STUN_UNREACHABLE` fires
- [ ] Manual smoke on Firefox — confirm `iceGatheringState` flip is detected identically