### PR TITLE
feat(media): hot-swap microphone during active calls

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -42,10 +42,46 @@ Retorna os dispositivos de entrada e saída atualmente selecionados.
 
 ## Trocando o microfone
 
-Chame `setMicrophone` em um dispositivo obtido via `getDevices()`, ou acesse o `MediaManager` subjacente pelo socket interno do dispositivo. Na prática, o `MediaManager` é acessado indiretamente: a biblioteca realiza uma troca a quente sem interrupção enquanto uma chamada está ativa.
+Use `wavoip.setMicrophone(deviceId)` para escolher o microfone antes ou durante uma chamada. Se houver uma chamada ativa, a troca acontece a quente — o áudio continua sem corte.
+
+```typescript
+const { err } = await wavoip.setMicrophone(mic.deviceId)
+if (err) console.error(err)
+```
+
+As facades de chamada (`CallActive` e `CallOutgoing`) também expõem `setMicrophone(deviceId)` com a mesma semântica — útil quando você só tem o objeto da chamada em mãos.
+
+```typescript
+await callActive.setMicrophone(mic.deviceId)
+await callOutgoing.setMicrophone(mic.deviceId)
+```
+
+### Evento `micChanged`
+
+Disparado sempre que o microfone ativo muda — seja por chamada explícita a `setMicrophone`, seja porque o dispositivo atual foi desconectado fisicamente.
+
+```typescript
+wavoip.on("micChanged", (device) => {
+    if (!device) console.warn("Microfone removido")
+    else console.log("Novo microfone:", device.label)
+})
+
+callActive.on("micChanged", (device) => { /* mesma assinatura */ })
+callOutgoing.on("micChanged", (device) => { /* mesma assinatura */ })
+```
+
+### Evento `devicesChanged`
+
+Disparado quando a lista de dispositivos do sistema muda (conectar/desconectar fones, por exemplo). Use para atualizar seletores em tela.
+
+```typescript
+wavoip.on("devicesChanged", (devices) => {
+    // re-render dropdowns
+})
+```
 
 {% hint style="info" %}
-A troca de microfone e alto-falante é tratada internamente pelo `MediaManager` compartilhado. As preferências de dispositivo são aplicadas a todas as chamadas ativas e futuras automaticamente.
+A troca a quente substitui a track de áudio dentro do `MediaStream` compartilhado. No transporte WebRTC chamamos `RTCRtpSender.replaceTrack`; no transporte WebSocket recriamos o `MediaStreamAudioSourceNode` mantendo o worklet de resample.
 {% endhint %}
 
 ---

--- a/src/Wavoip.ts
+++ b/src/Wavoip.ts
@@ -8,6 +8,8 @@ import { type Language, setLanguage } from "@/modules/shared/i18n";
 
 type Events = {
     offer: [offer: Offer];
+    micChanged: [device: MediaDeviceInfo | null];
+    devicesChanged: [devices: MediaDeviceInfo[]];
 };
 
 export class Wavoip extends EventEmitter<Events> {
@@ -25,6 +27,8 @@ export class Wavoip extends EventEmitter<Events> {
         setLanguage(params.language ?? "pt-BR");
 
         this.mediaManager = new MediaManager();
+        this.mediaManager.on("micChanged", (device) => this.emit("micChanged", device));
+        this.mediaManager.on("devicesChanged", (devices) => this.emit("devicesChanged", devices));
 
         for (const token of [...new Set(params.tokens)]) {
             const device = new DeviceConnection(this.mediaManager, token, params.platform);
@@ -60,6 +64,17 @@ export class Wavoip extends EventEmitter<Events> {
 
     getMultimediaDevices(): MediaDeviceInfo[] {
         return this.mediaManager.devices;
+    }
+
+    /**
+     * Switch the active microphone. If a call is in progress, the new device
+     * is hot-swapped into the live stream without interrupting audio.
+     * Returns `{ err: null }` on success or `{ err: string }` if the device id
+     * is not in the current device list.
+     */
+    async setMicrophone(deviceId: string): Promise<{ err: string | null }> {
+        const ok = await this.mediaManager.setMicrophone(deviceId);
+        return ok ? { err: null } : { err: `Microphone not found: ${deviceId}` };
     }
 
     /**

--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -15,6 +15,7 @@ export type CallActiveEvents = {
     serverStats: [stats: ServerCallStats];
     connectionStatus: [status: TransportStatus];
     status: [status: CallStatus];
+    micChanged: [device: MediaDeviceInfo | null];
 };
 
 export interface CallActive {
@@ -29,6 +30,7 @@ export interface CallActive {
     mute(): Promise<{ err: string | null }>;
     unmute(): Promise<{ err: string | null }>;
     end(): Promise<{ err: string | null }>;
+    setMicrophone(deviceId: string): Promise<{ err: string | null }>;
     on<T extends keyof CallActiveEvents>(event: T, callback: (...args: CallActiveEvents[T]) => void): Unsubscribe;
     /** @deprecated Use `on("error", callback)` instead. */
     onError(callback: (err: string) => void): void;
@@ -79,6 +81,9 @@ export function CallActiveProxy(
     bus.on("status", (status) => {
         emitter.emit("status", status);
     });
+    mediaManager.on("micChanged", (device) => {
+        emitter.emit("micChanged", device);
+    });
 
     let onErrorUnsub: Unsubscribe | undefined;
     let onPeerMuteUnsub: Unsubscribe | undefined;
@@ -112,6 +117,11 @@ export function CallActiveProxy(
             callbacks.onEnd(call);
             await transport.stop();
             return { err: null };
+        },
+
+        async setMicrophone(deviceId: string): Promise<{ err: string | null }> {
+            const ok = await mediaManager.setMicrophone(deviceId);
+            return ok ? { err: null } : { err: `Microphone not found: ${deviceId}` };
         },
 
         on<T extends keyof CallActiveEvents>(event: T, callback: (...args: CallActiveEvents[T]) => void): Unsubscribe {

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -15,6 +15,7 @@ export type CallOutgoingEvents = {
     unanswered: [];
     ended: [];
     status: [status: CallStatus];
+    micChanged: [device: MediaDeviceInfo | null];
 };
 
 export interface CallOutgoing {
@@ -24,6 +25,7 @@ export interface CallOutgoing {
     peer: CallPeer;
     device_token: string;
     status: CallStatus;
+    setMicrophone(deviceId: string): Promise<{ err: string | null }>;
     on<T extends keyof CallOutgoingEvents>(event: T, callback: (...args: CallOutgoingEvents[T]) => void): Unsubscribe;
     /** @deprecated Use `on("peerAccept", callback)` instead. */
     onPeerAccept(callback: (call: CallActive) => void): void;
@@ -87,6 +89,9 @@ export function CallOutgoingProxy(
     bus.on("status", (status) => {
         emitter.emit("status", status);
     });
+    mediaManager.on("micChanged", (device) => {
+        emitter.emit("micChanged", device);
+    });
 
     let onPeerAcceptUnsub: Unsubscribe | undefined;
     let onPeerRejectUnsub: Unsubscribe | undefined;
@@ -127,6 +132,11 @@ export function CallOutgoingProxy(
                     resolve(res.type === "error" ? { err: res.result } : { err: null });
                 });
             });
+        },
+
+        async setMicrophone(deviceId: string): Promise<{ err: string | null }> {
+            const ok = await mediaManager.setMicrophone(deviceId);
+            return ok ? { err: null } : { err: `Microphone not found: ${deviceId}` };
         },
 
         on<T extends keyof CallOutgoingEvents>(

--- a/src/modules/media/MediaManager.ts
+++ b/src/modules/media/MediaManager.ts
@@ -5,6 +5,13 @@ import outWorkletUrl from "../worklets/AudioWorkletOut.ts?worklet";
 export type MediaManagerEvents = {
     devicesChanged: [devices: MediaDeviceInfo[]];
     micChanged: [device: MediaDeviceInfo | null];
+    /**
+     * Fired after the mic track inside the live stream is hot-swapped
+     * (setMicrophone called while a stream is active). Transports subscribe to
+     * react: WebRTCTransport calls `sender.replaceTrack`, WebsocketTransport
+     * rebuilds its MediaStreamAudioSourceNode against the updated stream.
+     */
+    micTrackReplaced: [track: MediaStreamTrack];
     speakerChanged: [device: MediaDeviceInfo | null];
     muteChanged: [muted: boolean];
 };
@@ -170,6 +177,7 @@ export class MediaManager extends EventEmitter<MediaManagerEvents> {
 
         this.activeMic = device;
         this.emit("micChanged", device);
+        this.emit("micTrackReplaced", newTrack);
         return true;
     }
 

--- a/src/modules/media/WebRTC.ts
+++ b/src/modules/media/WebRTC.ts
@@ -1,7 +1,7 @@
 import type { CallStats } from "@/modules/call/Stats";
 import type { Events, ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
-import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 
 export class WebRTCTransport extends EventEmitter<Events> implements ITransport {
     status: TransportStatus = "disconnected";
@@ -32,12 +32,20 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     private answerResolver: PromiseWithResolvers<RTCSessionDescriptionInit>;
     private statsJob = 0;
     private started = false;
+    private senders: RTCRtpSender[] = [];
+    private unsubMicTrackReplaced?: Unsubscribe;
 
     constructor(
         private readonly mediaManager: MediaManager,
         offer?: string,
     ) {
         super();
+
+        this.unsubMicTrackReplaced = this.mediaManager.on("micTrackReplaced", (track) => {
+            for (const sender of this.senders) {
+                sender.replaceTrack(track).catch((err) => console.warn("[WebRTCTransport] replaceTrack failed:", err));
+            }
+        });
 
         this.pc = new RTCPeerConnection({ iceServers: [{ urls: "stun:stun.l.google.com:19302" }] });
         if (offer) this.remoteOffer = { type: "offer", sdp: offer };
@@ -107,7 +115,7 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
 
             for (const track of micStream.getTracks()) {
                 track.enabled = true;
-                this.pc.addTrack(track, micStream);
+                this.senders.push(this.pc.addTrack(track, micStream));
             }
 
             await this.pc.setRemoteDescription(this.remoteOffer);
@@ -128,7 +136,7 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
 
         for (const track of micStream.getTracks()) {
             track.enabled = true;
-            this.pc.addTrack(track, micStream);
+            this.senders.push(this.pc.addTrack(track, micStream));
         }
 
         const offer = await this.pc.createOffer();
@@ -154,6 +162,9 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
 
     async stop(): Promise<void> {
         clearInterval(this.statsJob);
+        this.unsubMicTrackReplaced?.();
+        this.unsubMicTrackReplaced = undefined;
+        this.senders = [];
 
         this.pc.close();
         await this.mediaManager.stopMedia();

--- a/src/modules/media/WebSocket.ts
+++ b/src/modules/media/WebSocket.ts
@@ -1,7 +1,7 @@
 import type { CallStats } from "@/modules/call/Stats";
 import type { Events, ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
-import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 
 // 1000 = Normal Closure (server intentionally ended the connection)
 // 1008 = Policy Violation (server rejected the connection, e.g. invalid token)
@@ -24,6 +24,7 @@ export class WebsocketTransport extends EventEmitter<Events> implements ITranspo
     private reconnectDeadline: ReturnType<typeof setTimeout> | null = null;
     private readonly audioIn: AudioInput;
     private readonly audioOut: AudioOutput;
+    private unsubMicTrackReplaced?: Unsubscribe;
 
     constructor(
         private readonly mediaManager: MediaManager,
@@ -51,12 +52,19 @@ export class WebsocketTransport extends EventEmitter<Events> implements ITranspo
             }
         });
 
+        this.unsubMicTrackReplaced = this.mediaManager.on("micTrackReplaced", () => {
+            const updated = this.mediaManager.stream;
+            if (updated) this.audioIn.swapStream(updated);
+        });
+
         this.ws = this.connect();
     }
 
     async stop(): Promise<void> {
         this.stopped = true;
         this.clearReconnectDeadline();
+        this.unsubMicTrackReplaced?.();
+        this.unsubMicTrackReplaced = undefined;
 
         this.ws?.close();
         this.ws = undefined;
@@ -162,6 +170,19 @@ class AudioInput extends EventEmitter<AudioInputEvents> {
 
         // ResampleProcessor only processes — it does not connect to destination.
         // Output goes to the main thread via port.postMessage.
+    }
+
+    /**
+     * Replace the live mic stream without tearing down the resample worklet.
+     * MediaStreamAudioSourceNode binds to one track at construction, so a mid-call
+     * device swap requires recreating the source node and reconnecting to the
+     * existing resample node.
+     */
+    swapStream(stream: MediaStream): void {
+        if (!this.resampleNode) return;
+        if (this.source) this.source.disconnect(this.resampleNode);
+        this.source = this.audioContext.createMediaStreamSource(stream);
+        this.source.connect(this.resampleNode);
     }
 
     async stop(): Promise<void> {

--- a/src/test/call/CallActive.test.ts
+++ b/src/test/call/CallActive.test.ts
@@ -35,11 +35,21 @@ function makeMockTransport(overrides: Partial<ITransport> = {}): ITransport {
 }
 
 function makeMockMediaManager() {
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
     return {
         setMuted: vi.fn(),
+        setMicrophone: vi.fn().mockResolvedValue(true),
         startMedia: vi.fn(),
         stopMedia: vi.fn(),
         audioContext: {} as AudioContext,
+        on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+            if (!listeners.has(event)) listeners.set(event, new Set());
+            listeners.get(event)?.add(cb);
+            return () => listeners.get(event)?.delete(cb);
+        }),
+        emit: (event: string, ...args: unknown[]) => {
+            for (const fn of listeners.get(event) ?? []) fn(...args);
+        },
     };
 }
 
@@ -240,6 +250,47 @@ describe("CallActive", () => {
             bus.emit("connectionStatus", "connected");
 
             expect(cb).toHaveBeenCalledWith("connected");
+        });
+
+        it("setMicrophone delegates to mediaManager.setMicrophone", async () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+
+            const result = await active.setMicrophone("mic-2");
+
+            expect(mm.setMicrophone).toHaveBeenCalledWith("mic-2");
+            expect(result).toEqual({ err: null });
+        });
+
+        it("setMicrophone returns err string when delegate returns false", async () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            mm.setMicrophone.mockResolvedValueOnce(false);
+            const active = CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+
+            const result = await active.setMicrophone("missing");
+
+            expect(result.err).toBeTruthy();
+        });
+
+        it("on('micChanged') fires when mediaManager emits micChanged", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+            const cb = vi.fn();
+            active.on("micChanged", cb);
+
+            const device = { kind: "audioinput", deviceId: "mic-2" } as MediaDeviceInfo;
+            mm.emit("micChanged", device);
+
+            expect(cb).toHaveBeenCalledWith(device);
         });
 
         it("onStatus fires when bus emits 'status'", () => {

--- a/src/test/call/CallOutgoing.test.ts
+++ b/src/test/call/CallOutgoing.test.ts
@@ -1,0 +1,83 @@
+import { CallBus } from "@/modules/call/CallBus";
+import { CallOutgoingProxy } from "@/modules/call/CallOutgoing";
+import { Call } from "@/modules/device/Call";
+import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { describe, expect, it, vi } from "vitest";
+
+const peer = { phone: "5511999999999", displayName: "Test", profilePicture: null };
+
+function makeCall() {
+    return Call.CreateOffer("call-1", "OFFICIAL", peer, "device-token");
+}
+
+function makeMockBus(call: Call) {
+    const socket = new EventEmitter<Record<string, unknown[]>>() as never;
+    return new CallBus(call, socket);
+}
+
+function makeMockSocket() {
+    const e = new EventEmitter<Record<string, unknown[]>>();
+    return Object.assign(e, { emit: vi.fn() }) as never;
+}
+
+function makeMockMediaManager() {
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    return {
+        setMuted: vi.fn(),
+        setMicrophone: vi.fn().mockResolvedValue(true),
+        startMedia: vi.fn(),
+        stopMedia: vi.fn(),
+        audioContext: {} as AudioContext,
+        on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+            if (!listeners.has(event)) listeners.set(event, new Set());
+            listeners.get(event)?.add(cb);
+            return () => listeners.get(event)?.delete(cb);
+        }),
+        emit: (event: string, ...args: unknown[]) => {
+            for (const fn of listeners.get(event) ?? []) fn(...args);
+        },
+    };
+}
+
+describe("CallOutgoing.setMicrophone", () => {
+    it("delegates to mediaManager.setMicrophone", async () => {
+        const call = makeCall();
+        const bus = makeMockBus(call);
+        const wss = makeMockSocket();
+        const mm = makeMockMediaManager();
+        const outgoing = CallOutgoingProxy(call, bus, wss, mm as never);
+
+        const result = await outgoing.setMicrophone("mic-2");
+
+        expect(mm.setMicrophone).toHaveBeenCalledWith("mic-2");
+        expect(result).toEqual({ err: null });
+    });
+
+    it("returns err when delegate fails", async () => {
+        const call = makeCall();
+        const bus = makeMockBus(call);
+        const wss = makeMockSocket();
+        const mm = makeMockMediaManager();
+        mm.setMicrophone.mockResolvedValueOnce(false);
+        const outgoing = CallOutgoingProxy(call, bus, wss, mm as never);
+
+        const result = await outgoing.setMicrophone("missing");
+
+        expect(result.err).toBeTruthy();
+    });
+
+    it("on('micChanged') fires when mediaManager emits micChanged", () => {
+        const call = makeCall();
+        const bus = makeMockBus(call);
+        const wss = makeMockSocket();
+        const mm = makeMockMediaManager();
+        const outgoing = CallOutgoingProxy(call, bus, wss, mm as never);
+        const cb = vi.fn();
+        outgoing.on("micChanged", cb);
+
+        const device = { kind: "audioinput", deviceId: "mic-2" } as MediaDeviceInfo;
+        mm.emit("micChanged", device);
+
+        expect(cb).toHaveBeenCalledWith(device);
+    });
+});

--- a/src/test/device/DeviceConnection.test.ts
+++ b/src/test/device/DeviceConnection.test.ts
@@ -78,7 +78,7 @@ import type { CallType } from "@/modules/device/Call";
 const peer = { phone: "5511999999999", displayName: "Test", profilePicture: null };
 
 function makeMockMediaManager(): MediaManager {
-    return {} as MediaManager;
+    return { on: vi.fn(() => () => {}) } as unknown as MediaManager;
 }
 
 function makeDeviceConnection() {

--- a/src/test/media/MediaManager.test.ts
+++ b/src/test/media/MediaManager.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../modules/worklets/AudioWorkletMic.ts?worklet", () => ({ default: "mock-mic-worklet.js" }));
+vi.mock("../../modules/worklets/AudioWorkletOut.ts?worklet", () => ({ default: "mock-out-worklet.js" }));
+
+const { MediaManager } = await import("@/modules/media/MediaManager");
+
+// ---------------------------------------------------------------------------
+// Mock browser APIs
+// ---------------------------------------------------------------------------
+
+class MockAudioContext {
+    state: "suspended" | "running" | "closed" = "suspended";
+    destination = {};
+    audioWorklet = { addModule: vi.fn().mockResolvedValue(undefined) };
+    suspend = vi.fn().mockImplementation(async () => {
+        this.state = "suspended";
+    });
+    resume = vi.fn().mockImplementation(async () => {
+        this.state = "running";
+    });
+    close = vi.fn().mockResolvedValue(undefined);
+}
+
+function makeMockTrack(id: string) {
+    return {
+        id,
+        kind: "audio",
+        enabled: true,
+        stop: vi.fn(),
+        getSettings: () => ({ deviceId: id }),
+    } as unknown as MediaStreamTrack;
+}
+
+function makeMockStream(track: MediaStreamTrack) {
+    const tracks: MediaStreamTrack[] = [track];
+    return {
+        id: "stream",
+        getTracks: () => tracks.slice(),
+        getAudioTracks: () => tracks.slice(),
+        addTrack: vi.fn((t: MediaStreamTrack) => tracks.push(t)),
+        removeTrack: vi.fn((t: MediaStreamTrack) => {
+            const idx = tracks.indexOf(t);
+            if (idx >= 0) tracks.splice(idx, 1);
+        }),
+    } as unknown as MediaStream;
+}
+
+const mic1 = { kind: "audioinput", deviceId: "mic-1", label: "Mic 1" } as MediaDeviceInfo;
+const mic2 = { kind: "audioinput", deviceId: "mic-2", label: "Mic 2" } as MediaDeviceInfo;
+const spk1 = { kind: "audiooutput", deviceId: "spk-1", label: "Speaker 1" } as MediaDeviceInfo;
+
+function stubMediaDevices(devices: MediaDeviceInfo[], getUserMedia: ReturnType<typeof vi.fn>) {
+    const stub = {
+        enumerateDevices: vi.fn().mockResolvedValue(devices),
+        getUserMedia,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    };
+    vi.stubGlobal("navigator", { mediaDevices: stub });
+    return stub;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MediaManager.setMicrophone", () => {
+    beforeEach(() => {
+        vi.stubGlobal("AudioContext", MockAudioContext);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("returns false for unknown deviceId", async () => {
+        stubMediaDevices([mic1, spk1], vi.fn());
+        const mm = new MediaManager();
+        await mm.waitReady();
+
+        const ok = await mm.setMicrophone("does-not-exist");
+
+        expect(ok).toBe(false);
+    });
+
+    it("with no active stream: stores activeMic and emits micChanged only", async () => {
+        stubMediaDevices([mic1, mic2, spk1], vi.fn());
+        const mm = new MediaManager();
+        await mm.waitReady();
+
+        const micChanged = vi.fn();
+        const micReplaced = vi.fn();
+        mm.on("micChanged", micChanged);
+        mm.on("micTrackReplaced", micReplaced);
+
+        const ok = await mm.setMicrophone("mic-2");
+
+        expect(ok).toBe(true);
+        expect(mm.activeMic).toEqual(mic2);
+        expect(micChanged).toHaveBeenCalledWith(mic2);
+        expect(micReplaced).not.toHaveBeenCalled();
+    });
+
+    it("with active stream: swaps track in-place, stops old, emits micChanged + micTrackReplaced", async () => {
+        const oldTrack = makeMockTrack("mic-1");
+        const newTrack = makeMockTrack("mic-2");
+        const stream = makeMockStream(oldTrack);
+        const newStream = makeMockStream(newTrack);
+
+        const getUserMedia = vi
+            .fn()
+            .mockResolvedValueOnce(stream) // initial startMedia
+            .mockResolvedValueOnce(newStream); // setMicrophone hot-swap
+
+        stubMediaDevices([mic1, mic2, spk1], getUserMedia);
+
+        const mm = new MediaManager();
+        await mm.waitReady();
+        await mm.startMedia();
+
+        const micChanged = vi.fn();
+        const micReplaced = vi.fn();
+        mm.on("micChanged", micChanged);
+        mm.on("micTrackReplaced", micReplaced);
+
+        const ok = await mm.setMicrophone("mic-2");
+
+        expect(ok).toBe(true);
+        expect(oldTrack.stop).toHaveBeenCalledOnce();
+        expect(stream.getAudioTracks()).toEqual([newTrack]);
+        expect(mm.activeMic).toEqual(mic2);
+        expect(micChanged).toHaveBeenCalledWith(mic2);
+        expect(micReplaced).toHaveBeenCalledWith(newTrack);
+    });
+
+    it("hot-swap preserves mute state on new track", async () => {
+        const oldTrack = makeMockTrack("mic-1");
+        const newTrack = makeMockTrack("mic-2");
+        const stream = makeMockStream(oldTrack);
+        const newStream = makeMockStream(newTrack);
+
+        const getUserMedia = vi.fn().mockResolvedValueOnce(stream).mockResolvedValueOnce(newStream);
+        stubMediaDevices([mic1, mic2, spk1], getUserMedia);
+
+        const mm = new MediaManager();
+        await mm.waitReady();
+        await mm.startMedia();
+        mm.setMuted(true);
+
+        await mm.setMicrophone("mic-2");
+
+        expect(newTrack.enabled).toBe(false);
+    });
+});

--- a/src/test/media/WebRTCTransport.test.ts
+++ b/src/test/media/WebRTCTransport.test.ts
@@ -29,7 +29,7 @@ class MockRTCPeerConnection {
 
     private eventListeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
-    addTrack = vi.fn();
+    addTrack = vi.fn(() => ({ replaceTrack: vi.fn().mockResolvedValue(undefined) }));
     close = vi.fn();
     setRemoteDescription = vi.fn().mockResolvedValue(undefined);
     createAnswer = vi.fn().mockResolvedValue({ type: "answer", sdp: "mock-answer-sdp" });
@@ -97,11 +97,21 @@ function makeMockMediaManager() {
         id: "mic-stream",
     } as unknown as MediaStream;
 
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
     return {
         setMuted: vi.fn(),
         startMedia: vi.fn().mockResolvedValue(mockStream),
         stopMedia: vi.fn().mockResolvedValue(undefined),
         audioContext,
+        on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+            if (!listeners.has(event)) listeners.set(event, new Set());
+            listeners.get(event)?.add(cb);
+            return () => listeners.get(event)?.delete(cb);
+        }),
+        emit: (event: string, ...args: unknown[]) => {
+            for (const fn of listeners.get(event) ?? []) fn(...args);
+        },
         _analyser: analyser,
         _stream: mockStream,
         _track: mockTrack,
@@ -324,6 +334,39 @@ describe("WebRTCTransport", () => {
             mockPcInstance._remoteTrack?.dispatchEvent("mute");
 
             expect(cb).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("microphone hot-swap", () => {
+        it("on mediaManager 'micTrackReplaced' → sender.replaceTrack(newTrack) called", async () => {
+            vi.useFakeTimers();
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, "offer-sdp");
+            await startTransport(transport);
+
+            const sender = mockPcInstance.addTrack.mock.results[0]?.value as { replaceTrack: ReturnType<typeof vi.fn> };
+            const newTrack = { id: "new-track" } as unknown as MediaStreamTrack;
+
+            mm.emit("micTrackReplaced", newTrack);
+            await Promise.resolve();
+
+            expect(sender.replaceTrack).toHaveBeenCalledWith(newTrack);
+        });
+
+        it("after stop(), 'micTrackReplaced' does not call replaceTrack", async () => {
+            vi.useFakeTimers();
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, "offer-sdp");
+            await startTransport(transport);
+
+            const sender = mockPcInstance.addTrack.mock.results[0]?.value as { replaceTrack: ReturnType<typeof vi.fn> };
+            await transport.stop();
+
+            const newTrack = { id: "new-track" } as unknown as MediaStreamTrack;
+            mm.emit("micTrackReplaced", newTrack);
+            await Promise.resolve();
+
+            expect(sender.replaceTrack).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## Summary
- New `micTrackReplaced` event on `MediaManager` fires after `setMicrophone` swaps the live track.
- `WebRTCTransport` now stores `RTCRtpSender`s and calls `replaceTrack` on swap — previously the peer kept receiving the stopped track.
- `WebsocketTransport` recreates its `MediaStreamAudioSourceNode` against the updated stream — previously the resample worklet rendered the stopped track.
- Public surface: `wavoip.setMicrophone`, `callActive.setMicrophone`, `callOutgoing.setMicrophone`, plus `micChanged` and `devicesChanged` events on `Wavoip`/facades.
- Docs in `docs/media.md` updated (pt-BR).

## Test plan
- [x] 138 unit tests pass (`pnpm test`)
- [x] Lint + build clean (`pnpm lint && pnpm build`)
- [ ] Manual: switch mic mid-call on a WebRTC call → peer hears new device, no glitch
- [ ] Manual: switch mic mid-call on a WebSocket call → peer hears new device, no glitch
- [ ] Manual: unplug current mic during call → `micChanged(null)` fires