### PR TITLE
fix(call): release mic when call ends

### DIFF
--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -57,8 +57,16 @@ export function CallActiveProxy(
 ): CallActive {
     const emitter = new EventEmitter<CallActiveEvents>();
 
+    let disposed = false;
+    const dispose = (): Promise<void> => {
+        if (disposed) return Promise.resolve();
+        disposed = true;
+        return Promise.resolve(transport.stop()).catch(() => {});
+    };
+
     bus.on("failed", (err) => {
         emitter.emit("error", err);
+        void dispose();
     });
     bus.on("peerMuted", (muted) => {
         if (muted) emitter.emit("peerMute");
@@ -66,6 +74,7 @@ export function CallActiveProxy(
     });
     bus.on("ended", () => {
         emitter.emit("ended");
+        void dispose();
     });
     bus.on("stats", (stats) => {
         emitter.emit("stats", stats);
@@ -109,8 +118,9 @@ export function CallActiveProxy(
         },
 
         async end(): Promise<{ err: string | null }> {
+            if (disposed) return { err: null };
             callbacks.onEnd(call);
-            await transport.stop();
+            await dispose();
             return { err: null };
         },
 

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -49,15 +49,25 @@ export function CallOutgoingProxy(
 ): CallOutgoing {
     const emitter = new EventEmitter<CallOutgoingEvents>();
 
+    let disposed = false;
+    const dispose = (): Promise<void> => {
+        if (disposed) return Promise.resolve();
+        disposed = true;
+        if (!preBuiltTransport) return Promise.resolve();
+        return Promise.resolve(preBuiltTransport.stop()).catch(() => {});
+    };
+
     bus.on("answered", async (mediaPlan) => {
         call.accept();
 
         let transport: ITransport;
         if (preBuiltTransport && mediaPlan.type === "webRTC") {
+            disposed = true;
             await preBuiltTransport.setAnswer(mediaPlan.sdp);
             await preBuiltTransport.start();
             transport = preBuiltTransport;
         } else {
+            await dispose();
             transport = createTransport(mediaPlan, mediaManager, call.deviceToken);
             await transport.start();
 
@@ -77,12 +87,15 @@ export function CallOutgoingProxy(
     });
     bus.on("rejected", () => {
         emitter.emit("peerReject");
+        void dispose();
     });
     bus.on("unanswered", () => {
         emitter.emit("unanswered");
+        void dispose();
     });
     bus.on("ended", () => {
         emitter.emit("ended");
+        void dispose();
     });
     bus.on("status", (status) => {
         emitter.emit("status", status);
@@ -122,8 +135,9 @@ export function CallOutgoingProxy(
 
         end(): Promise<{ err: string | null }> {
             return new Promise((resolve) => {
-                wss.emit("call.cancel", call.id, (res) => {
+                wss.emit("call.cancel", call.id, async (res) => {
                     call.cancel();
+                    await dispose();
                     resolve(res.type === "error" ? { err: res.result } : { err: null });
                 });
             });

--- a/src/modules/media/WebRTC.ts
+++ b/src/modules/media/WebRTC.ts
@@ -32,6 +32,7 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     private answerResolver: PromiseWithResolvers<RTCSessionDescriptionInit>;
     private statsJob = 0;
     private started = false;
+    private stopped = false;
 
     constructor(
         private readonly mediaManager: MediaManager,
@@ -153,6 +154,9 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     }
 
     async stop(): Promise<void> {
+        if (this.stopped) return;
+        this.stopped = true;
+
         clearInterval(this.statsJob);
 
         this.pc.close();

--- a/src/test/call/CallActive.test.ts
+++ b/src/test/call/CallActive.test.ts
@@ -138,6 +138,73 @@ describe("CallActive", () => {
             expect(transport.stop).toHaveBeenCalledOnce();
             expect(result).toEqual({ err: null });
         });
+
+        it("is idempotent — calling end() twice still stops transport once", async () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+
+            await active.end();
+            await active.end();
+
+            expect(transport.stop).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe("terminal cleanup (mic release)", () => {
+        it("bus 'ended' calls transport.stop()", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+
+            bus.emit("ended");
+
+            expect(transport.stop).toHaveBeenCalledOnce();
+        });
+
+        it("bus 'failed' calls transport.stop()", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+
+            bus.emit("failed", "boom");
+
+            expect(transport.stop).toHaveBeenCalledOnce();
+        });
+
+        it("local end() then bus 'ended' still stops transport once", async () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+
+            await active.end();
+            bus.emit("ended");
+
+            expect(transport.stop).toHaveBeenCalledOnce();
+        });
+
+        it("ended consumer event still fires after dispose", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, bus, transport, mm as never, { onEnd: vi.fn() });
+            const cb = vi.fn();
+            active.on("ended", cb);
+
+            bus.emit("ended");
+
+            expect(cb).toHaveBeenCalledOnce();
+            expect(transport.stop).toHaveBeenCalledOnce();
+        });
     });
 
     describe("event subscriptions", () => {

--- a/src/test/call/CallOutgoing.test.ts
+++ b/src/test/call/CallOutgoing.test.ts
@@ -1,0 +1,212 @@
+import { CallOutgoingProxy } from "@/modules/call/CallOutgoing";
+import { CallBus } from "@/modules/call/CallBus";
+import { Call } from "@/modules/device/Call";
+import type { DeviceSocket } from "@/modules/device/WebSocket";
+import type { WebRTCTransport } from "@/modules/media/WebRTC";
+import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { describe, expect, it, vi } from "vitest";
+
+const peer = { phone: "5511999999999", displayName: "Test", profilePicture: null };
+
+function makeCall() {
+    return new Call("call-1", "OFFICIAL", "OUTGOING", peer, "device-token", "RINGING");
+}
+
+function makeMockSocket() {
+    const socket = new EventEmitter<Record<string, unknown[]>>() as unknown as DeviceSocket & {
+        emit: ReturnType<typeof vi.fn>;
+    };
+    socket.emit = vi.fn((_event: string, ..._args: unknown[]) => {
+        const ack = _args[_args.length - 1];
+        if (typeof ack === "function") (ack as (r: unknown) => void)({ type: "success" });
+        return socket;
+    }) as never;
+    return socket;
+}
+
+function makeMockBus(call: Call) {
+    const socket = new EventEmitter<Record<string, unknown[]>>() as never;
+    return new CallBus(call, socket);
+}
+
+function makeMockMediaManager() {
+    return {
+        setMuted: vi.fn(),
+        startMedia: vi.fn(),
+        stopMedia: vi.fn(),
+        audioContext: {} as AudioContext,
+    };
+}
+
+function makeMockPreBuiltTransport() {
+    const t = new EventEmitter() as unknown as WebRTCTransport & {
+        stop: ReturnType<typeof vi.fn>;
+        start: ReturnType<typeof vi.fn>;
+        setAnswer: ReturnType<typeof vi.fn>;
+    };
+    t.stop = vi.fn().mockResolvedValue(undefined);
+    t.start = vi.fn().mockResolvedValue(undefined);
+    t.setAnswer = vi.fn().mockResolvedValue(undefined);
+    (t as unknown as { status: string }).status = "disconnected";
+    (t as unknown as { peerMuted: boolean }).peerMuted = false;
+    (t as unknown as { audioAnalyser: Promise<AnalyserNode> }).audioAnalyser = Promise.resolve({} as AnalyserNode);
+    (t as unknown as { stats: object }).stats = {
+        rtt: { min: 0, max: 0, avg: 0 },
+        tx: { total: 0, total_bytes: 0, loss: 0 },
+        rx: { total: 0, total_bytes: 0, loss: 0 },
+    };
+    return t;
+}
+
+describe("CallOutgoing", () => {
+    describe("terminal cleanup (mic release pre-answer)", () => {
+        it("stops preBuiltTransport on bus 'rejected'", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            CallOutgoingProxy(call, bus, socket, mm as never, preBuilt);
+
+            bus.emit("rejected");
+
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+        });
+
+        it("stops preBuiltTransport on bus 'unanswered'", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            CallOutgoingProxy(call, bus, socket, mm as never, preBuilt);
+
+            bus.emit("unanswered");
+
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+        });
+
+        it("stops preBuiltTransport on bus 'ended' before answer", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            CallOutgoingProxy(call, bus, socket, mm as never, preBuilt);
+
+            bus.emit("ended");
+
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+        });
+
+        it("stops preBuiltTransport when consumer calls end()", async () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            const outgoing = CallOutgoingProxy(call, bus, socket, mm as never, preBuilt);
+
+            await outgoing.end();
+
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+        });
+
+        it("does not stop preBuiltTransport on 'answered' (handoff to CallActive)", async () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            CallOutgoingProxy(call, bus, socket, mm as never, preBuilt);
+
+            bus.emit("answered", { type: "webRTC", sdp: "answer-sdp" });
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(preBuilt.stop).not.toHaveBeenCalled();
+        });
+
+        it("after answered handoff, bus 'ended' stops transport at most once (CallActive owns it)", async () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            CallOutgoingProxy(call, bus, socket, mm as never, preBuilt);
+
+            bus.emit("answered", { type: "webRTC", sdp: "answer-sdp" });
+            await new Promise((r) => setTimeout(r, 0));
+
+            bus.emit("ended");
+
+            expect(preBuilt.stop).toHaveBeenCalledTimes(1);
+        });
+
+        it("is idempotent — multiple terminal events stop preBuiltTransport once", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            CallOutgoingProxy(call, bus, socket, mm as never, preBuilt);
+
+            bus.emit("rejected");
+            bus.emit("ended");
+            bus.emit("unanswered");
+
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+        });
+
+        it("no preBuiltTransport — terminal events do not throw", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+
+            CallOutgoingProxy(call, bus, socket, mm as never);
+
+            expect(() => bus.emit("ended")).not.toThrow();
+            expect(() => bus.emit("rejected")).not.toThrow();
+            expect(() => bus.emit("unanswered")).not.toThrow();
+        });
+    });
+
+    describe("event forwarding", () => {
+        it("forwards 'ended' to consumer", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+
+            const outgoing = CallOutgoingProxy(call, bus, socket, mm as never);
+            const cb = vi.fn();
+            outgoing.on("ended", cb);
+
+            bus.emit("ended");
+
+            expect(cb).toHaveBeenCalledOnce();
+        });
+
+        it("forwards 'rejected' to peerReject consumer event", () => {
+            const call = makeCall();
+            const bus = makeMockBus(call);
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+
+            const outgoing = CallOutgoingProxy(call, bus, socket, mm as never);
+            const cb = vi.fn();
+            outgoing.on("peerReject", cb);
+
+            bus.emit("rejected");
+
+            expect(cb).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/test/media/WebRTCTransport.test.ts
+++ b/src/test/media/WebRTCTransport.test.ts
@@ -197,6 +197,19 @@ describe("WebRTCTransport", () => {
             expect(mockPcInstance.close).toHaveBeenCalledOnce();
             expect(mm.stopMedia).toHaveBeenCalledOnce();
         });
+
+        it("is idempotent — second stop() does not re-close pc or re-stop media", async () => {
+            vi.useFakeTimers();
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, "offer-sdp");
+            await startTransport(transport);
+
+            await transport.stop();
+            await transport.stop();
+
+            expect(mockPcInstance.close).toHaveBeenCalledOnce();
+            expect(mm.stopMedia).toHaveBeenCalledOnce();
+        });
     });
 
     describe("ontrack event", () => {


### PR DESCRIPTION
## Summary
- Bug: microphone stays active (tab mic icon persists) after a call ends because `transport.stop()` only runs on the local end path. Peer-side `call:ended`, `call:failed`, peer reject/unanswered, and pre-answer cancel paths all leak the mic stream.
- `CallActive`: idempotent `dispose()` calls `transport.stop()` on `bus.on("ended")` / `bus.on("failed")` and routes `end()` through the same path.
- `CallOutgoing`: idempotent `dispose()` stops the pre-built WebRTC transport on `rejected` / `unanswered` / `ended` / consumer `end()`. Ownership handed to `CallActive` on `answered` to avoid double-stop.
- `WebRTCTransport.stop()` guarded with `stopped` flag so repeated calls are no-ops.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 142 tests pass (10 new behavior tests)
- [x] `pnpm build` clean
- [x] Manual: incoming WebRTC call, peer hangs up → tab mic icon disappears
- [x] Manual: outgoing OFFICIAL call, cancel before answer → tab mic icon disappears
- [x] Manual: outgoing OFFICIAL call, peer rejects/unanswered → tab mic icon disappears
- [x] Manual: outgoing unofficial (WS) call, peer hangs up → tab mic icon disappears