### PR TITLE
fix: honor stopped flag in reconnect to prevent zombie sockets

### DIFF
--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -244,8 +244,8 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
     }
 
     disconnect() {
-        if (this.wss.disconnected) return;
         this.stopped = true;
+        if (this.wss.disconnected) return;
         this.wss.disconnect();
     }
 
@@ -265,10 +265,12 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
     }
 
     private reconnect(attempt = 1) {
-        if (attempt === 3 || this.wss.connected) return;
+        if (attempt === 3 || this.wss.connected || this.stopped) return;
 
         setTimeout(async () => {
+            if (this.stopped) return;
             const infos = await this.getInfos();
+            if (this.stopped) return;
             if (!infos) return this.reconnect(attempt + 1);
             this.device.status = infos.status;
             this.wss.connect();


### PR DESCRIPTION
## Summary
Pending `setTimeout` in `DeviceConnection.reconnect()` did not check `this.stopped`, so it would still call `wss.connect()` after the consumer had already called `device.disconnect()`. Also `disconnect()` early-returned when `wss.disconnected`, leaving `stopped` as `false` and the reconnect timer free to fire.

Result: zombie sockets when the consumer unmounted during a server-side disconnect (e.g., navigating away while the device was hibernating).

## Changes
- `disconnect()`: set `stopped = true` before the `wss.disconnected` early return.
- `reconnect()`: guard scheduling on `stopped`. Re-check `stopped` after the timer fires and again after the `await getInfos()` yield point.

## Test plan
- [x] Device hibernates while consumer mounted → consumer unmounts mid-reconnect → no `wss.connect()` runs.
- [x] Normal flow (no disconnect call): hibernate → reconnect still completes.
- [x] Manual `disconnect()` then `connect()` → reconnect timer from the old session does not interfere.