### PR TITLE
feat: ICE diagnostics on single-Call model (Phase 3)

### DIFF
--- a/src/Wavoip.ts
+++ b/src/Wavoip.ts
@@ -2,6 +2,7 @@ import type { CallOutgoing } from "@/modules/call/CallOutgoing";
 import type { Offer } from "@/modules/call/Offer";
 import { type Device, DeviceConnection } from "@/modules/device/DeviceConnection";
 import { DeviceProxy } from "@/modules/device/DeviceProxy";
+import type { IceConfig } from "@/modules/media/ICEDiagnostics";
 import { MediaManager } from "@/modules/media/MediaManager";
 import { EventEmitter } from "@/modules/shared/EventEmitter";
 import { type Language, setLanguage } from "@/modules/shared/i18n";
@@ -12,6 +13,8 @@ type Events = {
 
 export class Wavoip extends EventEmitter<Events> {
     private readonly mediaManager: MediaManager;
+    private readonly iceConfig?: IceConfig;
+    private readonly platform?: string;
     private _devices: DeviceConnection[] = [];
     private _onOfferUnsub?: () => void;
 
@@ -19,15 +22,18 @@ export class Wavoip extends EventEmitter<Events> {
         tokens: string[];
         platform?: string;
         language?: Language;
+        iceConfig?: IceConfig;
     }) {
         super();
 
         setLanguage(params.language ?? "pt-BR");
 
         this.mediaManager = new MediaManager();
+        this.iceConfig = params.iceConfig;
+        this.platform = params.platform;
 
         for (const token of [...new Set(params.tokens)]) {
-            const device = new DeviceConnection(this.mediaManager, token, params.platform);
+            const device = new DeviceConnection(this.mediaManager, token, this.platform, this.iceConfig);
             this.bindDeviceEvents(device);
             this._devices.push(device);
         }
@@ -149,7 +155,7 @@ export class Wavoip extends EventEmitter<Events> {
         const added: DeviceConnection[] = [];
         for (const token of tokens) {
             if (this._devices.some((d) => d.token === token)) continue;
-            const device = new DeviceConnection(this.mediaManager, token);
+            const device = new DeviceConnection(this.mediaManager, token, this.platform, this.iceConfig);
             this._devices.push(device);
             added.push(device);
             this.bindDeviceEvents(device);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,15 @@ export type { DeviceStatus, Contact } from "@/modules/device/Device";
 export type { Device, DeviceEvents } from "@/modules/device/DeviceConnection";
 
 export type { TransportStatus } from "@/modules/media/ITransport";
+export type {
+    ConnectivityIssue,
+    IceCandidateKind,
+    IceConfig,
+    IceDiagnostics,
+} from "@/modules/media/ICEDiagnostics";
 export type { MediaManagerState } from "@/modules/media/MediaManager";
+export type { StunProbeResult } from "@/modules/media/StunProbe";
+export { runStunProbe } from "@/modules/media/StunProbe";
 export type { Unsubscribe } from "@/modules/shared/EventEmitter";
 export type { Language } from "@/modules/shared/i18n";
 

--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -1,6 +1,7 @@
 import type { CallPeer } from "@/modules/call/Peer";
 import type { CallStats, ServerCallStats } from "@/modules/call/Stats";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
@@ -14,6 +15,8 @@ export type CallActiveEvents = {
     serverStats: [stats: ServerCallStats];
     connectionStatus: [status: TransportStatus];
     status: [status: CallStatus];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export interface CallActive {
@@ -85,6 +88,12 @@ export function CallActiveProxy(
     });
     call.on("status", (status) => {
         emitter.emit("status", status);
+    });
+    call.on("iceDiagnostics", (diag) => {
+        emitter.emit("iceDiagnostics", diag);
+    });
+    call.on("connectivityIssue", (issue) => {
+        emitter.emit("connectivityIssue", issue);
     });
 
     let onErrorUnsub: Unsubscribe | undefined;

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -2,6 +2,7 @@ import { type CallActive, CallActiveProxy } from "@/modules/call/CallActive";
 import type { CallPeer } from "@/modules/call/Peer";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
 import type { DeviceSocket, MediaPlan } from "@/modules/device/WebSocket";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { WebRTCTransport } from "@/modules/media/WebRTC";
@@ -14,6 +15,8 @@ export type CallOutgoingEvents = {
     unanswered: [];
     ended: [];
     status: [status: CallStatus];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export interface CallOutgoing {
@@ -97,6 +100,12 @@ export function CallOutgoingProxy(
     });
     call.on("status", (status) => {
         emitter.emit("status", status);
+    });
+    call.on("iceDiagnostics", (diag) => {
+        emitter.emit("iceDiagnostics", diag);
+    });
+    call.on("connectivityIssue", (issue) => {
+        emitter.emit("connectivityIssue", issue);
     });
 
     let onPeerAcceptUnsub: Unsubscribe | undefined;

--- a/src/modules/call/Offer.ts
+++ b/src/modules/call/Offer.ts
@@ -1,6 +1,7 @@
 import type { CallActive } from "@/modules/call/CallActive";
 import type { CallPeer } from "@/modules/call/Peer";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 
 export type OfferEvents = {
@@ -9,6 +10,8 @@ export type OfferEvents = {
     unanswered: [];
     ended: [];
     status: [status: CallStatus];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export interface Offer {
@@ -74,6 +77,8 @@ export function OfferProxy(
         }),
     );
     callUnsubs.push(call.on("status", (status) => emitter.emit("status", status)));
+    callUnsubs.push(call.on("iceDiagnostics", (diag) => emitter.emit("iceDiagnostics", diag)));
+    callUnsubs.push(call.on("connectivityIssue", (issue) => emitter.emit("connectivityIssue", issue)));
 
     let onAcceptedElsewhereUnsub: Unsubscribe | undefined;
     let onRejectedElsewhereUnsub: Unsubscribe | undefined;

--- a/src/modules/device/Call.ts
+++ b/src/modules/device/Call.ts
@@ -1,5 +1,6 @@
 import type { CallStats, ServerCallStats } from "@/modules/call/Stats";
 import type { DeviceSocket, MediaPlan } from "@/modules/device/WebSocket";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
 import { EventEmitter } from "@/modules/shared/EventEmitter";
 
@@ -16,6 +17,8 @@ export type CallEvents = {
     peerMuted: [muted: boolean];
     stats: [stats: CallStats];
     serverStats: [stats: ServerCallStats];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export class Call extends EventEmitter<CallEvents> {
@@ -114,7 +117,8 @@ export class Call extends EventEmitter<CallEvents> {
 
     /**
      * Subscribe to transport events. Called after construction once a
-     * WebRTC/WebSocket transport is ready.
+     * WebRTC/WebSocket transport is ready. Replays any ICE diagnostics the
+     * transport gathered before being wired so late listeners catch up.
      */
     wireTransport(transport: ITransport): void {
         transport.on("statusChanged", (s) => {
@@ -123,6 +127,13 @@ export class Call extends EventEmitter<CallEvents> {
         });
         transport.on("peerMuted", (m) => this.emit("peerMuted", m));
         transport.on("statsChanged", (s) => this.emit("stats", s));
+        transport.on("iceDiagnostics", (d) => this.emit("iceDiagnostics", d));
+        transport.on("connectivityIssue", (i) => this.emit("connectivityIssue", i));
+
+        if (transport.lastDiagnostics) this.emit("iceDiagnostics", transport.lastDiagnostics);
+        if (transport.emittedConnectivityIssues) {
+            for (const issue of transport.emittedConnectivityIssues) this.emit("connectivityIssue", issue);
+        }
     }
 
     static CreateOffer(id: string, type: CallType, peer: Peer, deviceToken: string) {

--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -6,6 +6,7 @@ import { DeviceModel } from "@/modules/device/Device";
 import type { Contact, DeviceStatus } from "@/modules/device/Device";
 import { type DeviceSocket, DeviceWebSocketFactory } from "@/modules/device/WebSocket";
 import type { MediaPlan, MediaPlanRelay, MediaPlanWebRTC } from "@/modules/device/WebSocket";
+import type { IceConfig } from "@/modules/media/ICEDiagnostics";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { WebRTCTransport } from "@/modules/media/WebRTC";
 import { WebsocketTransport } from "@/modules/media/WebSocket";
@@ -59,6 +60,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
         private readonly mediaManager: MediaManager,
         token: string,
         platform?: string,
+        private readonly iceConfig?: IceConfig,
     ) {
         super();
 
@@ -161,7 +163,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
         let mediaPlan: MediaPlan;
         let preBuiltTransport: WebRTCTransport | undefined;
         if (this.device.callType === "OFFICIAL") {
-            preBuiltTransport = new WebRTCTransport(this.mediaManager);
+            preBuiltTransport = new WebRTCTransport(this.mediaManager, undefined, this.iceConfig);
             try {
                 const sdp = await preBuiltTransport.createOffer();
                 mediaPlan = { type: "webRTC", sdp };
@@ -321,7 +323,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
     }
 
     private async acceptWebRTCOffer(call: Call, mediaPlan: MediaPlanWebRTC): Promise<CallActive> {
-        const webRTC = new WebRTCTransport(this.mediaManager, mediaPlan.sdp);
+        const webRTC = new WebRTCTransport(this.mediaManager, mediaPlan.sdp, this.iceConfig);
         await webRTC.start();
 
         const answer = await webRTC.answer;

--- a/src/modules/media/ICEDiagnostics.ts
+++ b/src/modules/media/ICEDiagnostics.ts
@@ -1,0 +1,38 @@
+export type IceCandidateKind = "host" | "srflx" | "prflx" | "relay";
+
+export type IceDiagnostics = {
+    gatheringDurationMs: number;
+    gatheringTimedOut: boolean;
+    candidatesByType: Record<IceCandidateKind, number>;
+    stunReached: boolean;
+    turnReached: boolean;
+    selectedCandidatePair?: {
+        local: IceCandidateKind;
+        remote: IceCandidateKind;
+        rtt?: number;
+    };
+};
+
+export type ConnectivityIssue =
+    | "STUN_UNREACHABLE"
+    | "ICE_GATHERING_TIMEOUT"
+    | "ICE_CONNECTION_FAILED"
+    | "NO_HOST_CANDIDATES"
+    | "SYMMETRIC_NAT_SUSPECTED";
+
+export type IceConfig = {
+    gatheringTimeoutMs?: number;
+    iceServers?: RTCIceServer[];
+};
+
+export const DEFAULT_ICE_GATHERING_TIMEOUT_MS = 2500;
+
+export const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
+    {
+        urls: [
+            "stun:stun.l.google.com:19302",
+            "stun:stun1.l.google.com:19302",
+            "stun:stun.cloudflare.com:3478",
+        ],
+    },
+];

--- a/src/modules/media/ITransport.ts
+++ b/src/modules/media/ITransport.ts
@@ -18,6 +18,11 @@ export interface ITransport extends EventEmitter<Events> {
     audioAnalyser: Promise<AnalyserNode>;
     stats: CallStats;
 
+    /** Last `iceDiagnostics` payload emitted, if any. Used by Call.wireTransport to replay. */
+    lastDiagnostics?: IceDiagnostics | null;
+    /** Set of `connectivityIssue`s already fired. Used by Call.wireTransport to replay. */
+    emittedConnectivityIssues?: ReadonlySet<ConnectivityIssue>;
+
     start(): Promise<void>;
     stop(): Promise<void>;
 }

--- a/src/modules/media/ITransport.ts
+++ b/src/modules/media/ITransport.ts
@@ -1,4 +1,5 @@
 import type { CallStats } from "@/modules/call/Stats";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { EventEmitter } from "@/modules/shared/EventEmitter";
 
 export type TransportStatus = "disconnected" | "connected" | "connecting" | "reconnecting";
@@ -7,6 +8,8 @@ export type Events = {
     statusChanged: [status: TransportStatus];
     statsChanged: [stats: CallStats];
     peerMuted: [muted: boolean];
+    iceDiagnostics: [diag: IceDiagnostics];
+    connectivityIssue: [issue: ConnectivityIssue];
 };
 
 export interface ITransport extends EventEmitter<Events> {

--- a/src/modules/media/StunProbe.ts
+++ b/src/modules/media/StunProbe.ts
@@ -1,0 +1,64 @@
+export type StunProbeResult = {
+    server: string;
+    reachable: boolean;
+    latencyMs?: number;
+};
+
+const DEFAULT_PROBE_TIMEOUT_MS = 3000;
+
+/**
+ * Probe a list of STUN servers in parallel. A server is reported as
+ * `reachable: true` when at least one `srflx` candidate is gathered before
+ * the timeout fires. Each probe uses its own throwaway RTCPeerConnection.
+ *
+ * @example
+ *   const results = await runStunProbe([
+ *       "stun:stun.l.google.com:19302",
+ *       "stun:stun.cloudflare.com:3478",
+ *   ]);
+ */
+export function runStunProbe(
+    servers: string[],
+    timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS,
+): Promise<StunProbeResult[]> {
+    return Promise.all(servers.map((server) => probeOne(server, timeoutMs)));
+}
+
+function probeOne(server: string, timeoutMs: number): Promise<StunProbeResult> {
+    return new Promise((resolve) => {
+        const startedAt = Date.now();
+        const pc = new RTCPeerConnection({ iceServers: [{ urls: server }] });
+        let settled = false;
+
+        const cleanup = () => {
+            settled = true;
+            clearTimeout(timer);
+            pc.close();
+        };
+
+        const finish = (result: StunProbeResult) => {
+            if (settled) return;
+            cleanup();
+            resolve(result);
+        };
+
+        pc.onicecandidate = (event) => {
+            if (!event.candidate) return;
+            if (event.candidate.type !== "srflx") return;
+            finish({ server, reachable: true, latencyMs: Date.now() - startedAt });
+        };
+
+        const timer = setTimeout(() => {
+            finish({ server, reachable: false });
+        }, timeoutMs);
+
+        try {
+            pc.createDataChannel("probe");
+            pc.createOffer()
+                .then((offer) => pc.setLocalDescription(offer))
+                .catch(() => finish({ server, reachable: false }));
+        } catch {
+            finish({ server, reachable: false });
+        }
+    });
+}

--- a/src/modules/media/WebRTC.ts
+++ b/src/modules/media/WebRTC.ts
@@ -42,7 +42,12 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
         relay: 0,
     };
     private symmetricNatTimer = 0;
-    private emittedIssues = new Set<ConnectivityIssue>();
+    private _emittedConnectivityIssues = new Set<ConnectivityIssue>();
+    lastDiagnostics: IceDiagnostics | null = null;
+
+    get emittedConnectivityIssues(): ReadonlySet<ConnectivityIssue> {
+        return this._emittedConnectivityIssues;
+    }
 
     constructor(
         private readonly mediaManager: MediaManager,
@@ -184,6 +189,7 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
             stunReached,
             turnReached,
         };
+        this.lastDiagnostics = diag;
         this.emit("iceDiagnostics", diag);
 
         if (timedOut) this.emitIssue("ICE_GATHERING_TIMEOUT");
@@ -224,8 +230,8 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     }
 
     private emitIssue(issue: ConnectivityIssue) {
-        if (this.emittedIssues.has(issue)) return;
-        this.emittedIssues.add(issue);
+        if (this._emittedConnectivityIssues.has(issue)) return;
+        this._emittedConnectivityIssues.add(issue);
         this.emit("connectivityIssue", issue);
     }
 

--- a/src/modules/media/WebRTC.ts
+++ b/src/modules/media/WebRTC.ts
@@ -1,28 +1,26 @@
 import type { CallStats } from "@/modules/call/Stats";
+import {
+    type ConnectivityIssue,
+    DEFAULT_ICE_GATHERING_TIMEOUT_MS,
+    DEFAULT_ICE_SERVERS,
+    type IceCandidateKind,
+    type IceConfig,
+    type IceDiagnostics,
+} from "@/modules/media/ICEDiagnostics";
 import type { Events, ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { EventEmitter } from "@/modules/shared/EventEmitter";
+
+const SYMMETRIC_NAT_DETECTION_WINDOW_MS = 10_000;
 
 export class WebRTCTransport extends EventEmitter<Events> implements ITransport {
     status: TransportStatus = "disconnected";
     peerMuted = false;
     audioAnalyser: Promise<AnalyserNode>;
     stats: CallStats = {
-        rtt: {
-            min: 0,
-            max: 0,
-            avg: 0,
-        },
-        tx: {
-            total: 0,
-            total_bytes: 0,
-            loss: 0,
-        },
-        rx: {
-            total: 0,
-            total_bytes: 0,
-            loss: 0,
-        },
+        rtt: { min: 0, max: 0, avg: 0 },
+        tx: { total: 0, total_bytes: 0, loss: 0 },
+        rx: { total: 0, total_bytes: 0, loss: 0 },
     };
 
     readonly answer: Promise<RTCSessionDescriptionInit>;
@@ -35,13 +33,28 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     private offerCreated = false;
     private stopped = false;
 
+    private readonly gatheringTimeoutMs: number;
+    private gatheringStartedAt = 0;
+    private candidatesByType: Record<IceCandidateKind, number> = {
+        host: 0,
+        srflx: 0,
+        prflx: 0,
+        relay: 0,
+    };
+    private symmetricNatTimer = 0;
+    private emittedIssues = new Set<ConnectivityIssue>();
+
     constructor(
         private readonly mediaManager: MediaManager,
         offer?: string,
+        iceConfig?: IceConfig,
     ) {
         super();
 
-        this.pc = new RTCPeerConnection({ iceServers: [{ urls: "stun:stun.l.google.com:19302" }] });
+        this.gatheringTimeoutMs = iceConfig?.gatheringTimeoutMs ?? DEFAULT_ICE_GATHERING_TIMEOUT_MS;
+        const iceServers = iceConfig?.iceServers ?? DEFAULT_ICE_SERVERS;
+
+        this.pc = new RTCPeerConnection({ iceServers });
         if (offer) this.remoteOffer = { type: "offer", sdp: offer };
 
         const { promise: audioAnalyserPromise, resolve: resolveAudioAnalyser } = Promise.withResolvers<AnalyserNode>();
@@ -49,6 +62,22 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
 
         this.answerResolver = Promise.withResolvers<RTCSessionDescriptionInit>();
         this.answer = this.answerResolver.promise;
+
+        this.pc.onicecandidate = (event) => {
+            const candidate = event.candidate;
+            if (!candidate) return;
+            const kind = candidate.type as IceCandidateKind | undefined;
+            if (kind && kind in this.candidatesByType) this.candidatesByType[kind] += 1;
+        };
+
+        this.pc.oniceconnectionstatechange = () => {
+            if (this.pc.iceConnectionState === "failed") {
+                this.emitIssue("ICE_CONNECTION_FAILED");
+            }
+            if (this.pc.iceConnectionState === "connected" || this.pc.iceConnectionState === "completed") {
+                clearTimeout(this.symmetricNatTimer);
+            }
+        };
 
         this.pc.ontrack = (event) => {
             const remoteStream = event.streams[0];
@@ -82,21 +111,12 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
         };
 
         this.pc.onconnectionstatechange = () => {
-            if (this.pc.connectionState === "connecting") {
-                this.setStatus("connecting");
-            }
-
-            if (this.pc.connectionState === "disconnected" || this.pc?.connectionState === "closed") {
+            if (this.pc.connectionState === "connecting") this.setStatus("connecting");
+            if (this.pc.connectionState === "disconnected" || this.pc.connectionState === "closed") {
                 this.setStatus("disconnected");
             }
-
-            if (this.pc.connectionState === "closed") {
-                this.mediaManager.stopMedia();
-            }
-
-            if (this.pc.connectionState === "connected") {
-                this.setStatus("connected");
-            }
+            if (this.pc.connectionState === "closed") this.mediaManager.stopMedia();
+            if (this.pc.connectionState === "connected") this.setStatus("connected");
         };
     }
 
@@ -149,12 +169,64 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
     }
 
     private async waitForIceGathering(): Promise<void> {
-        if (this.pc.iceGatheringState === "complete") return;
-        await new Promise<void>((resolve) => {
-            this.pc.addEventListener("icegatheringstatechange", () => {
-                if (this.pc.iceGatheringState === "complete") resolve();
-            });
+        this.gatheringStartedAt = Date.now();
+
+        const timedOut = await this.raceGatheringWithTimeout();
+
+        const duration = Date.now() - this.gatheringStartedAt;
+        const stunReached = this.candidatesByType.srflx > 0;
+        const turnReached = this.candidatesByType.relay > 0;
+
+        const diag: IceDiagnostics = {
+            gatheringDurationMs: duration,
+            gatheringTimedOut: timedOut,
+            candidatesByType: { ...this.candidatesByType },
+            stunReached,
+            turnReached,
+        };
+        this.emit("iceDiagnostics", diag);
+
+        if (timedOut) this.emitIssue("ICE_GATHERING_TIMEOUT");
+        if (timedOut && !stunReached) this.emitIssue("STUN_UNREACHABLE");
+        if (this.candidatesByType.host === 0) this.emitIssue("NO_HOST_CANDIDATES");
+
+        this.scheduleSymmetricNatCheck(stunReached);
+    }
+
+    private raceGatheringWithTimeout(): Promise<boolean> {
+        if (this.pc.iceGatheringState === "complete") return Promise.resolve(false);
+
+        return new Promise<boolean>((resolve) => {
+            const handler = () => {
+                if (this.pc.iceGatheringState !== "complete") return;
+                this.pc.removeEventListener("icegatheringstatechange", handler);
+                clearTimeout(timer);
+                resolve(false);
+            };
+
+            const timer = setTimeout(() => {
+                this.pc.removeEventListener("icegatheringstatechange", handler);
+                resolve(true);
+            }, this.gatheringTimeoutMs);
+
+            this.pc.addEventListener("icegatheringstatechange", handler);
         });
+    }
+
+    private scheduleSymmetricNatCheck(stunReached: boolean) {
+        if (!stunReached) return;
+        if (this.symmetricNatTimer) return;
+        this.symmetricNatTimer = setTimeout(() => {
+            const noConnection =
+                this.pc.iceConnectionState !== "connected" && this.pc.iceConnectionState !== "completed";
+            if (noConnection) this.emitIssue("SYMMETRIC_NAT_SUSPECTED");
+        }, SYMMETRIC_NAT_DETECTION_WINDOW_MS) as unknown as number;
+    }
+
+    private emitIssue(issue: ConnectivityIssue) {
+        if (this.emittedIssues.has(issue)) return;
+        this.emittedIssues.add(issue);
+        this.emit("connectivityIssue", issue);
     }
 
     async stop(): Promise<void> {
@@ -162,6 +234,7 @@ export class WebRTCTransport extends EventEmitter<Events> implements ITransport 
         this.stopped = true;
 
         clearInterval(this.statsJob);
+        clearTimeout(this.symmetricNatTimer);
 
         this.pc.close();
         await this.mediaManager.stopMedia();

--- a/src/test/Wavoip.ice-config.spec.ts
+++ b/src/test/Wavoip.ice-config.spec.ts
@@ -1,0 +1,79 @@
+import { Wavoip } from "@/Wavoip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const deviceConnectionInstances: Array<{ token: string; iceConfig?: unknown; platform?: string }> = [];
+
+vi.mock("@/modules/media/MediaManager", () => {
+    return {
+        MediaManager: class {
+            devices: never[] = [];
+            activeMic = undefined;
+            activeSpeaker = undefined;
+            on() {
+                return () => {};
+            }
+        },
+    };
+});
+
+vi.mock("@/modules/device/DeviceConnection", () => {
+    return {
+        DeviceConnection: class {
+            token: string;
+            iceConfig: unknown;
+            platform: string | undefined;
+            constructor(_mm: unknown, token: string, platform?: string, iceConfig?: unknown) {
+                this.token = token;
+                this.platform = platform;
+                this.iceConfig = iceConfig;
+                deviceConnectionInstances.push(this);
+            }
+            on() {
+                return () => {};
+            }
+        },
+    };
+});
+
+describe("Wavoip iceConfig", () => {
+    beforeEach(() => {
+        deviceConnectionInstances.length = 0;
+    });
+
+    afterEach(() => {
+        deviceConnectionInstances.length = 0;
+    });
+
+    it("passes iceConfig through to every DeviceConnection on construction", () => {
+        const iceConfig = {
+            gatheringTimeoutMs: 1500,
+            iceServers: [{ urls: "stun:custom.example:3478" }],
+        };
+        new Wavoip({ tokens: ["a", "b"], iceConfig });
+
+        expect(deviceConnectionInstances).toHaveLength(2);
+        expect(deviceConnectionInstances[0].iceConfig).toEqual(iceConfig);
+        expect(deviceConnectionInstances[1].iceConfig).toEqual(iceConfig);
+    });
+
+    it("passes iceConfig through to DeviceConnection added via addDevices", () => {
+        const iceConfig = { gatheringTimeoutMs: 2000 };
+        const wavoip = new Wavoip({ tokens: [], iceConfig });
+        wavoip.addDevices(["c"]);
+
+        expect(deviceConnectionInstances).toHaveLength(1);
+        expect(deviceConnectionInstances[0].iceConfig).toEqual(iceConfig);
+    });
+
+    it("does not require iceConfig", () => {
+        expect(() => new Wavoip({ tokens: ["a"] })).not.toThrow();
+        expect(deviceConnectionInstances[0].iceConfig).toBeUndefined();
+    });
+
+    it("preserves platform alongside iceConfig", () => {
+        new Wavoip({ tokens: ["a"], platform: "web", iceConfig: { gatheringTimeoutMs: 1000 } });
+
+        expect(deviceConnectionInstances[0].platform).toBe("web");
+        expect(deviceConnectionInstances[0].iceConfig).toEqual({ gatheringTimeoutMs: 1000 });
+    });
+});

--- a/src/test/call/CallOutgoing.diagnostics.spec.ts
+++ b/src/test/call/CallOutgoing.diagnostics.spec.ts
@@ -1,0 +1,66 @@
+import { CallOutgoingProxy } from "@/modules/call/CallOutgoing";
+import { Call } from "@/modules/device/Call";
+import type { DeviceSocket } from "@/modules/device/WebSocket";
+import type { IceDiagnostics } from "@/modules/media/ICEDiagnostics";
+import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { describe, expect, it, vi } from "vitest";
+
+const peer = { phone: "5511999999999", displayName: "Test", profilePicture: null };
+
+function makeCall() {
+    return new Call("call-1", "OFFICIAL", "OUTGOING", peer, "device-token", "RINGING");
+}
+
+function makeMockSocket() {
+    const socket = new EventEmitter<Record<string, unknown[]>>() as unknown as DeviceSocket & {
+        emit: ReturnType<typeof vi.fn>;
+    };
+    socket.emit = vi.fn(() => socket) as never;
+    return socket;
+}
+
+function makeMockMediaManager() {
+    return {
+        setMuted: vi.fn(),
+        startMedia: vi.fn(),
+        stopMedia: vi.fn(),
+        audioContext: {} as AudioContext,
+    };
+}
+
+describe("CallOutgoing diagnostics pass-through", () => {
+    it("forwards call iceDiagnostics to consumer", () => {
+        const call = makeCall();
+        const socket = makeMockSocket();
+        const mm = makeMockMediaManager();
+        const outgoing = CallOutgoingProxy(call, socket, mm as never);
+
+        const cb = vi.fn();
+        outgoing.on("iceDiagnostics", cb);
+
+        const diag: IceDiagnostics = {
+            gatheringDurationMs: 50,
+            gatheringTimedOut: false,
+            candidatesByType: { host: 1, srflx: 1, prflx: 0, relay: 0 },
+            stunReached: true,
+            turnReached: false,
+        };
+        call.emit("iceDiagnostics", diag);
+
+        expect(cb).toHaveBeenCalledWith(diag);
+    });
+
+    it("forwards call connectivityIssue to consumer", () => {
+        const call = makeCall();
+        const socket = makeMockSocket();
+        const mm = makeMockMediaManager();
+        const outgoing = CallOutgoingProxy(call, socket, mm as never);
+
+        const cb = vi.fn();
+        outgoing.on("connectivityIssue", cb);
+
+        call.emit("connectivityIssue", "STUN_UNREACHABLE");
+
+        expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+    });
+});

--- a/src/test/device/Call.wire.test.ts
+++ b/src/test/device/Call.wire.test.ts
@@ -1,6 +1,7 @@
 import type { CallStats, ServerCallStats } from "@/modules/call/Stats";
 import { Call } from "@/modules/device/Call";
 import type { ServerEvents } from "@/modules/device/WebSocket";
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, Events as TransportEvents } from "@/modules/media/ITransport";
 import { EventEmitter } from "@/modules/shared/EventEmitter";
 import { describe, expect, it, vi } from "vitest";
@@ -297,5 +298,75 @@ describe("Call.wireTransport", () => {
         (transport as unknown as EventEmitter<TransportEvents>).emit("statsChanged", stats);
 
         expect(cb).toHaveBeenCalledWith(stats);
+    });
+
+    it("transport iceDiagnostics → emits iceDiagnostics", () => {
+        const call = makeCall();
+        const transport = makeMockTransport();
+        const cb = vi.fn();
+        call.on("iceDiagnostics", cb);
+
+        const diag: IceDiagnostics = {
+            gatheringDurationMs: 100,
+            gatheringTimedOut: false,
+            candidatesByType: { host: 1, srflx: 1, prflx: 0, relay: 0 },
+            stunReached: true,
+            turnReached: false,
+        };
+
+        call.wireTransport(transport);
+        (transport as unknown as EventEmitter<TransportEvents>).emit("iceDiagnostics", diag);
+
+        expect(cb).toHaveBeenCalledWith(diag);
+    });
+
+    it("transport connectivityIssue → emits connectivityIssue", () => {
+        const call = makeCall();
+        const transport = makeMockTransport();
+        const cb = vi.fn();
+        call.on("connectivityIssue", cb);
+
+        call.wireTransport(transport);
+        (transport as unknown as EventEmitter<TransportEvents>).emit("connectivityIssue", "STUN_UNREACHABLE");
+
+        expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+    });
+
+    it("replays transport.lastDiagnostics when wired late", () => {
+        const call = makeCall();
+        const transport = makeMockTransport();
+        const diag: IceDiagnostics = {
+            gatheringDurationMs: 200,
+            gatheringTimedOut: false,
+            candidatesByType: { host: 2, srflx: 1, prflx: 0, relay: 0 },
+            stunReached: true,
+            turnReached: false,
+        };
+        transport.lastDiagnostics = diag;
+
+        const cb = vi.fn();
+        call.on("iceDiagnostics", cb);
+
+        call.wireTransport(transport);
+
+        expect(cb).toHaveBeenCalledWith(diag);
+    });
+
+    it("replays transport.emittedConnectivityIssues when wired late", () => {
+        const call = makeCall();
+        const transport = makeMockTransport();
+        const issues = new Set<ConnectivityIssue>(["STUN_UNREACHABLE", "NO_HOST_CANDIDATES"]);
+        Object.defineProperty(transport, "emittedConnectivityIssues", {
+            get: () => issues,
+        });
+
+        const cb = vi.fn();
+        call.on("connectivityIssue", cb);
+
+        call.wireTransport(transport);
+
+        expect(cb).toHaveBeenCalledWith("STUN_UNREACHABLE");
+        expect(cb).toHaveBeenCalledWith("NO_HOST_CANDIDATES");
+        expect(cb).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/test/media/StunProbe.spec.ts
+++ b/src/test/media/StunProbe.spec.ts
@@ -1,0 +1,81 @@
+import { runStunProbe } from "@/modules/media/StunProbe";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMockPeerConnection } from "./ice-test-helpers";
+
+describe("runStunProbe", () => {
+    const pcFactory = buildMockPeerConnection();
+
+    beforeEach(() => {
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it("returns reachable=true when an srflx candidate is gathered before the timeout", async () => {
+        const probe = runStunProbe(["stun:server-a.example:3478"], 1000);
+
+        await vi.advanceTimersByTimeAsync(10);
+        pcFactory.instances[0]._fireIceCandidate("srflx");
+        await vi.advanceTimersByTimeAsync(10);
+
+        const results = await probe;
+        expect(results).toHaveLength(1);
+        expect(results[0].server).toBe("stun:server-a.example:3478");
+        expect(results[0].reachable).toBe(true);
+        expect(results[0].latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns reachable=false when no srflx candidate arrives before the timeout", async () => {
+        const probe = runStunProbe(["stun:dead.example:3478"], 500);
+
+        await vi.advanceTimersByTimeAsync(600);
+
+        const results = await probe;
+        expect(results[0].reachable).toBe(false);
+        expect(results[0].latencyMs).toBeUndefined();
+    });
+
+    it("probes every server in parallel and returns a result per server", async () => {
+        const probe = runStunProbe(["stun:a.example:3478", "stun:b.example:3478", "stun:c.example:3478"], 1000);
+
+        await vi.advanceTimersByTimeAsync(10);
+        expect(pcFactory.instances).toHaveLength(3);
+        pcFactory.instances[0]._fireIceCandidate("srflx");
+        pcFactory.instances[2]._fireIceCandidate("srflx");
+        await vi.advanceTimersByTimeAsync(1100);
+
+        const results = await probe;
+        expect(results.map((r) => r.server)).toEqual([
+            "stun:a.example:3478",
+            "stun:b.example:3478",
+            "stun:c.example:3478",
+        ]);
+        expect(results[0].reachable).toBe(true);
+        expect(results[1].reachable).toBe(false);
+        expect(results[2].reachable).toBe(true);
+    });
+
+    it("closes every RTCPeerConnection after the probe finishes", async () => {
+        const probe = runStunProbe(["stun:a.example:3478", "stun:b.example:3478"], 300);
+
+        await vi.advanceTimersByTimeAsync(400);
+        await probe;
+
+        for (const pc of pcFactory.instances) {
+            expect(pc.close).toHaveBeenCalled();
+        }
+    });
+
+    it("uses a default timeout when none is provided", async () => {
+        const probe = runStunProbe(["stun:a.example:3478"]);
+
+        await vi.advanceTimersByTimeAsync(5000);
+        const results = await probe;
+        expect(results).toHaveLength(1);
+    });
+});

--- a/src/test/media/WebRTCTransport.ice-config.spec.ts
+++ b/src/test/media/WebRTCTransport.ice-config.spec.ts
@@ -1,0 +1,42 @@
+import { WebRTCTransport } from "@/modules/media/WebRTC";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockAudio, buildMockPeerConnection, makeMockMediaManager } from "./ice-test-helpers";
+
+describe("WebRTCTransport ICE server config", () => {
+    const pcFactory = buildMockPeerConnection();
+
+    beforeEach(() => {
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.stubGlobal("Audio", MockAudio);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("uses multiple default STUN servers when no iceServers configured", () => {
+        const mm = makeMockMediaManager();
+        new WebRTCTransport(mm as never);
+
+        const config = pcFactory.last()._config;
+        expect(config.iceServers).toBeDefined();
+        const servers = config.iceServers ?? [];
+        const urls = servers
+            .flatMap((s) => (Array.isArray(s.urls) ? s.urls : [s.urls]))
+            .filter((u): u is string => typeof u === "string");
+        expect(urls.length).toBeGreaterThanOrEqual(2);
+        expect(urls.every((u) => u.startsWith("stun:"))).toBe(true);
+    });
+
+    it("uses iceServers from config when provided", () => {
+        const mm = makeMockMediaManager();
+        const custom: RTCIceServer[] = [
+            { urls: "stun:my-stun.example.com:3478" },
+            { urls: ["turn:my-turn.example.com:3478"], username: "u", credential: "c" },
+        ];
+        new WebRTCTransport(mm as never, undefined, { iceServers: custom });
+
+        expect(pcFactory.last()._config.iceServers).toEqual(custom);
+    });
+});

--- a/src/test/media/WebRTCTransport.ice-diagnostics.spec.ts
+++ b/src/test/media/WebRTCTransport.ice-diagnostics.spec.ts
@@ -1,0 +1,194 @@
+import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
+import { WebRTCTransport } from "@/modules/media/WebRTC";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockAudio, buildMockPeerConnection, makeMockMediaManager } from "./ice-test-helpers";
+
+describe("WebRTCTransport ICE diagnostics", () => {
+    const pcFactory = buildMockPeerConnection();
+
+    beforeEach(() => {
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.stubGlobal("Audio", MockAudio);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    describe("candidate counting", () => {
+        it("counts candidates by type from onicecandidate events", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const diagPromise = new Promise<IceDiagnostics>((resolve) => {
+                transport.on("iceDiagnostics", resolve);
+            });
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("host");
+            pc._fireIceCandidate("host");
+            pc._fireIceCandidate("srflx");
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            const diag = await diagPromise;
+            expect(diag.candidatesByType.host).toBe(2);
+            expect(diag.candidatesByType.srflx).toBe(1);
+            expect(diag.candidatesByType.relay).toBe(0);
+            expect(diag.candidatesByType.prflx).toBe(0);
+        });
+    });
+
+    describe("iceDiagnostics event", () => {
+        it("emits with gatheringTimedOut=false when gathering completes in time", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const cb = vi.fn();
+            transport.on("iceDiagnostics", cb);
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("srflx");
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            expect(cb).toHaveBeenCalledTimes(1);
+            const diag = cb.mock.calls[0][0] as IceDiagnostics;
+            expect(diag.gatheringTimedOut).toBe(false);
+            expect(diag.stunReached).toBe(true);
+            expect(diag.turnReached).toBe(false);
+            expect(diag.gatheringDurationMs).toBeGreaterThanOrEqual(0);
+        });
+
+        it("emits with gatheringTimedOut=true when the timeout fires first", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 200 });
+
+            const cb = vi.fn();
+            transport.on("iceDiagnostics", cb);
+
+            const offerPromise = transport.createOffer();
+            pcFactory.last()._fireIceCandidate("host");
+            await vi.advanceTimersByTimeAsync(300);
+            await offerPromise;
+
+            expect(cb).toHaveBeenCalledTimes(1);
+            const diag = cb.mock.calls[0][0] as IceDiagnostics;
+            expect(diag.gatheringTimedOut).toBe(true);
+            expect(diag.stunReached).toBe(false);
+        });
+
+        it("sets turnReached=true when a relay candidate is gathered", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const cb = vi.fn();
+            transport.on("iceDiagnostics", cb);
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("relay");
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            const diag = cb.mock.calls[0][0] as IceDiagnostics;
+            expect(diag.turnReached).toBe(true);
+        });
+    });
+
+    describe("connectivityIssue event", () => {
+        it("emits STUN_UNREACHABLE when gathering times out without an srflx candidate", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 200 });
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            pcFactory.last()._fireIceCandidate("host");
+            await vi.advanceTimersByTimeAsync(300);
+            await offerPromise;
+
+            expect(issues).toContain("STUN_UNREACHABLE");
+        });
+
+        it("does not emit STUN_UNREACHABLE when an srflx candidate is gathered before timeout", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 200 });
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("host");
+            pc._fireIceCandidate("srflx");
+            await vi.advanceTimersByTimeAsync(50);
+            pc._completeGathering();
+            await offerPromise;
+
+            expect(issues).not.toContain("STUN_UNREACHABLE");
+        });
+
+        it("emits NO_HOST_CANDIDATES when gathering ends without a host candidate", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            pc._fireIceCandidate("srflx");
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            expect(issues).toContain("NO_HOST_CANDIDATES");
+        });
+
+        it("emits ICE_CONNECTION_FAILED when iceConnectionState transitions to failed", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            pc._fireIceConnectionState("failed");
+            expect(issues).toContain("ICE_CONNECTION_FAILED");
+        });
+
+        it("does not emit duplicates for the same issue", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const issues: ConnectivityIssue[] = [];
+            transport.on("connectivityIssue", (i) => issues.push(i));
+
+            const offerPromise = transport.createOffer();
+            const pc = pcFactory.last();
+            await vi.advanceTimersByTimeAsync(5);
+            pc._completeGathering();
+            await offerPromise;
+
+            pc._fireIceConnectionState("failed");
+            pc._fireIceConnectionState("failed");
+
+            expect(issues.filter((i) => i === "ICE_CONNECTION_FAILED")).toHaveLength(1);
+        });
+    });
+});

--- a/src/test/media/WebRTCTransport.ice-timeout.spec.ts
+++ b/src/test/media/WebRTCTransport.ice-timeout.spec.ts
@@ -1,0 +1,123 @@
+import { WebRTCTransport } from "@/modules/media/WebRTC";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockAudio, buildMockPeerConnection, makeMockMediaManager } from "./ice-test-helpers";
+
+describe("WebRTCTransport ICE gathering timeout", () => {
+    const pcFactory = buildMockPeerConnection();
+
+    beforeEach(() => {
+        pcFactory.reset();
+        vi.stubGlobal("RTCPeerConnection", pcFactory.MockRTCPeerConnection);
+        vi.stubGlobal("Audio", MockAudio);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    describe("createOffer (outgoing)", () => {
+        it("resolves immediately when gathering completes before the timeout", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const offerPromise = transport.createOffer();
+
+            await vi.advanceTimersByTimeAsync(10);
+            pcFactory.last()._completeGathering();
+
+            const sdp = await offerPromise;
+            expect(sdp).toBe("mock-answer-sdp");
+        });
+
+        it("resolves at the configured timeout when gathering never completes", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 800 });
+
+            const offerPromise = transport.createOffer();
+
+            await vi.advanceTimersByTimeAsync(799);
+            let settled = false;
+            offerPromise.then(() => {
+                settled = true;
+            });
+            await Promise.resolve();
+            expect(settled).toBe(false);
+
+            await vi.advanceTimersByTimeAsync(2);
+            await offerPromise;
+            expect(settled).toBe(true);
+        });
+
+        it("uses the 2500ms default timeout when none is configured", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const offerPromise = transport.createOffer();
+
+            await vi.advanceTimersByTimeAsync(2499);
+            let settled = false;
+            offerPromise.then(() => {
+                settled = true;
+            });
+            await Promise.resolve();
+            expect(settled).toBe(false);
+
+            await vi.advanceTimersByTimeAsync(2);
+            await offerPromise;
+            expect(settled).toBe(true);
+        });
+
+        it("removes the icegatheringstatechange listener after resolving on completion", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+
+            const offerPromise = transport.createOffer();
+            await vi.advanceTimersByTimeAsync(5);
+            pcFactory.last()._completeGathering();
+            await offerPromise;
+
+            const { added, removed } = pcFactory.last()._iceListenerCounts;
+            expect(added).toBeGreaterThan(0);
+            expect(removed).toBe(added);
+        });
+
+        it("removes the icegatheringstatechange listener after timing out", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, undefined, { gatheringTimeoutMs: 500 });
+
+            const offerPromise = transport.createOffer();
+            await vi.advanceTimersByTimeAsync(600);
+            await offerPromise;
+
+            const { added, removed } = pcFactory.last()._iceListenerCounts;
+            expect(added).toBeGreaterThan(0);
+            expect(removed).toBe(added);
+        });
+
+        it("returns immediately when gathering is already complete before waitForIceGathering attaches", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never);
+            pcFactory.last().iceGatheringState = "complete";
+
+            const sdp = await transport.createOffer();
+            expect(sdp).toBe("mock-answer-sdp");
+        });
+    });
+
+    describe("start (incoming) honors the same timeout cap", () => {
+        it("resolves the answer at the configured timeout when gathering hangs", async () => {
+            const mm = makeMockMediaManager();
+            const transport = new WebRTCTransport(mm as never, "offer-sdp", { gatheringTimeoutMs: 400 });
+
+            const startPromise = transport.start();
+
+            await vi.advanceTimersByTimeAsync(500);
+            await startPromise;
+
+            const answer = await transport.answer;
+            expect(answer.sdp).toBe("mock-answer-sdp");
+        });
+    });
+});

--- a/src/test/media/ice-test-helpers.ts
+++ b/src/test/media/ice-test-helpers.ts
@@ -1,0 +1,159 @@
+import { type Mock, vi } from "vitest";
+
+export class MockMediaStreamTrack {
+    private listeners = new Map<string, Set<() => void>>();
+    enabled = false;
+
+    addEventListener(event: string, listener: () => void) {
+        if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+        this.listeners.get(event)?.add(listener);
+    }
+
+    dispatchEvent(event: string) {
+        for (const listener of this.listeners.get(event) ?? []) listener();
+    }
+}
+
+/**
+ * Configurable mock RTCPeerConnection.
+ * Tests drive gathering completion + ICE state transitions manually via the
+ * `_*` helpers; unlike a real PC, nothing auto-completes.
+ */
+export class MockRTCPeerConnection {
+    _config: RTCConfiguration;
+    _iceListenerCounts = { added: 0, removed: 0 };
+
+    ontrack: ((e: RTCTrackEvent) => void) | null = null;
+    onconnectionstatechange: (() => void) | null = null;
+    onicecandidate: ((e: { candidate: RTCIceCandidate | null }) => void) | null = null;
+    oniceconnectionstatechange: (() => void) | null = null;
+
+    connectionState: RTCPeerConnectionState = "new";
+    iceConnectionState: RTCIceConnectionState = "new";
+    iceGatheringState: RTCIceGatheringState = "new";
+
+    addTrack: Mock = vi.fn();
+    close: Mock = vi.fn();
+    createDataChannel: Mock = vi.fn();
+    setRemoteDescription: Mock = vi.fn().mockResolvedValue(undefined);
+    createAnswer: Mock = vi.fn().mockResolvedValue({ type: "answer", sdp: "mock-answer-sdp" });
+    createOffer: Mock = vi.fn().mockResolvedValue({ type: "offer", sdp: "mock-offer-sdp" });
+    setLocalDescription: Mock = vi.fn().mockResolvedValue(undefined);
+    localDescription = { type: "answer", sdp: "mock-answer-sdp" } as RTCSessionDescription;
+    getStats: Mock = vi.fn().mockResolvedValue(new Map());
+
+    namedListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+    constructor(config?: RTCConfiguration) {
+        this._config = config ?? {};
+        instances.push(this);
+    }
+
+    addEventListener(event: string, listener: (...args: unknown[]) => void) {
+        if (!this.namedListeners.has(event)) this.namedListeners.set(event, new Set());
+        this.namedListeners.get(event)?.add(listener);
+        if (event === "icegatheringstatechange") this._iceListenerCounts.added += 1;
+    }
+
+    removeEventListener(event: string, listener: (...args: unknown[]) => void) {
+        this.namedListeners.get(event)?.delete(listener);
+        if (event === "icegatheringstatechange") this._iceListenerCounts.removed += 1;
+    }
+
+    dispatchEvent(event: string) {
+        for (const listener of this.namedListeners.get(event) ?? []) listener();
+    }
+
+    _completeGathering() {
+        this.iceGatheringState = "complete";
+        this.dispatchEvent("icegatheringstatechange");
+    }
+
+    _fireIceCandidate(type: RTCIceCandidateType) {
+        this.onicecandidate?.({ candidate: { type } as RTCIceCandidate });
+    }
+
+    _fireIceConnectionState(state: RTCIceConnectionState) {
+        this.iceConnectionState = state;
+        this.oniceconnectionstatechange?.();
+        this.dispatchEvent("iceconnectionstatechange");
+    }
+
+    _fireConnectionState(state: RTCPeerConnectionState) {
+        this.connectionState = state;
+        this.onconnectionstatechange?.();
+    }
+}
+
+const instances: MockRTCPeerConnection[] = [];
+
+export interface PcFactory {
+    MockRTCPeerConnection: typeof MockRTCPeerConnection;
+    instances: MockRTCPeerConnection[];
+    last(): MockRTCPeerConnection;
+    reset(): void;
+}
+
+export function buildMockPeerConnection(): PcFactory {
+    return {
+        MockRTCPeerConnection,
+        instances,
+        last(): MockRTCPeerConnection {
+            const inst = instances[instances.length - 1];
+            if (!inst) throw new Error("No RTCPeerConnection instance created yet");
+            return inst;
+        },
+        reset() {
+            instances.length = 0;
+        },
+    };
+}
+
+export interface MockMediaManager {
+    setMuted: Mock;
+    startMedia: Mock;
+    stopMedia: Mock;
+    audioContext: {
+        createMediaStreamSource: Mock;
+        createAnalyser: Mock;
+        destination: object;
+    };
+    _analyser: { fftSize: number; getByteTimeDomainData: Mock; connect: Mock };
+    _stream: MediaStream;
+    _track: MockMediaStreamTrack;
+}
+
+export function makeMockMediaManager(): MockMediaManager {
+    const analyser = {
+        fftSize: 256,
+        getByteTimeDomainData: vi.fn((arr: Uint8Array) => arr.fill(128)),
+        connect: vi.fn(),
+    };
+    const source = { connect: vi.fn() };
+    const audioContext = {
+        createMediaStreamSource: vi.fn().mockReturnValue(source),
+        createAnalyser: vi.fn().mockReturnValue(analyser),
+        destination: {},
+    };
+    const mockTrack = new MockMediaStreamTrack();
+    const mockStream = {
+        getTracks: vi.fn().mockReturnValue([mockTrack]),
+        getAudioTracks: vi.fn().mockReturnValue([mockTrack]),
+        id: "mic-stream",
+    } as unknown as MediaStream;
+
+    return {
+        setMuted: vi.fn(),
+        startMedia: vi.fn().mockResolvedValue(mockStream),
+        stopMedia: vi.fn().mockResolvedValue(undefined),
+        audioContext,
+        _analyser: analyser,
+        _stream: mockStream,
+        _track: mockTrack,
+    };
+}
+
+export class MockAudio {
+    muted = false;
+    srcObject: MediaStream | null = null;
+}


### PR DESCRIPTION
## Summary
Re-implements ICE diagnostics on top of the single-Call model from PR #21. **Base = refactor/single-call** — merge that one first.

## What is new
- `ICEDiagnostics.ts` — types: `IceDiagnostics`, `ConnectivityIssue`, `IceCandidateKind`, `IceConfig`, `DEFAULT_ICE_GATHERING_TIMEOUT_MS`, `DEFAULT_ICE_SERVERS`.
- `WebRTCTransport`:
  - Accepts optional `iceConfig` (third constructor arg).
  - Defaults to three STUN servers (Google + Cloudflare) instead of a single one.
  - Caps ICE gathering with a 2500 ms default timeout (configurable).
  - Counts candidates by type during gathering.
  - Emits `iceDiagnostics` summary (duration, timed out, candidate counts, stun/turn reached) once gathering settles.
  - Emits `connectivityIssue` for `ICE_GATHERING_TIMEOUT`, `STUN_UNREACHABLE`, `NO_HOST_CANDIDATES`, `ICE_CONNECTION_FAILED`, `SYMMETRIC_NAT_SUSPECTED` (deduped).
  - Caches `lastDiagnostics` + `emittedConnectivityIssues` so they can be replayed when a Call wires the transport late (outgoing flow: ICE gathering finishes inside `createOffer()` before the server responds with a call id).
- `Call.wireTransport`:
  - Forwards `iceDiagnostics` + `connectivityIssue` to the Call event stream.
  - Replays cached transport diagnostics on wire (covers pre-built outgoing transports + late offer accepts).
- Facades (`Offer`, `CallOutgoing`, `CallActive`): pass `iceDiagnostics` + `connectivityIssue` through to consumer subscribers.
- `Wavoip` constructor accepts optional `iceConfig`, plumbed into every `DeviceConnection` (including ones added later via `addDevices`). **Not** stored on `MediaManager` — moved to where it actually matters.
- `runStunProbe(servers, timeoutMs?)` utility exported for consumer-side pre-flight checks.
- Types `ConnectivityIssue`, `IceCandidateKind`, `IceConfig`, `IceDiagnostics`, `StunProbeResult` exported from the package entry.

## Design notes
- **No `StickyDiagnosticsEmitter`**. The original branch (`fix/ice-diagnostics`) carried a triple-stickiness layer (transport cache → bus sticky → facade sticky). On the new model the chain is shorter: transport caches → Call.wireTransport replays once → facade forwards. Consumers must subscribe before the transport is wired into the call, which is the natural ordering anyway (transport wiring only happens after the server `answered`/accept handshake).
- Pre-existing pre-built-outgoing race (transport finishes ICE before Call exists) is solved by the transport cache + wire-time replay rather than a sticky emitter.

## Tests
- 174 → 183 (+9 in this PR, +41 total across phases 1-3).
- New: `WebRTCTransport.ice-config.spec.ts`, `WebRTCTransport.ice-diagnostics.spec.ts`, `WebRTCTransport.ice-timeout.spec.ts`, `StunProbe.spec.ts`, `Wavoip.ice-config.spec.ts`, `CallOutgoing.diagnostics.spec.ts`, Call replay tests in `Call.wire.test.ts`.
- `pnpm lint`, `pnpm test`, `pnpm build` green on every commit.

## Commits
- `c91a2c1` feat(media): add ICEDiagnostics types + transport event signatures
- `fe232e3` feat(webrtc): cap ICE gathering with timeout, emit diagnostics + connectivity issues
- `dd5be16` feat(call): forward ICE diagnostics from transport and replay on wire
- `4844023` feat(call): pass iceDiagnostics and connectivityIssue through facades
- `cab6e4e` feat(wavoip): plumb iceConfig through Wavoip into DeviceConnection
- `73d24a4` feat(stun): add runStunProbe utility + export ICE types