### PR TITLE
fix(call): Sprint A — 5 P0 bug fixes (B1, B2, B3, B5, B7)

### DIFF
--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -109,14 +109,11 @@ export function CallActiveProxy(
     let onConnectionStatusUnsub: Unsubscribe | undefined;
     let onStatusUnsub: Unsubscribe | undefined;
 
-    return {
+    const proxy = {
         id: call.id,
         type: call.type,
         device_token: call.deviceToken,
         direction: call.direction,
-        status: call.status,
-        peer: { ...call.peer, muted: transport.peerMuted },
-        connection_status: transport.status,
         audio_analyser: transport.audioAnalyser,
 
         mute(): Promise<{ err: string | null }> {
@@ -190,5 +187,15 @@ export function CallActiveProxy(
             onStatusUnsub?.();
             onStatusUnsub = emitter.on("status", cb);
         },
-    };
+    } as CallActive;
+
+    // Live getters — Call.status, transport.status and transport.peerMuted change over the
+    // lifetime of the proxy. Snapshotting would freeze them at construction time.
+    Object.defineProperties(proxy, {
+        status: { get: () => call.status, enumerable: true },
+        connection_status: { get: () => transport.status, enumerable: true },
+        peer: { get: () => ({ ...call.peer, muted: transport.peerMuted }), enumerable: true },
+    });
+
+    return proxy;
 }

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -114,13 +114,11 @@ export function CallOutgoingProxy(
     let onEndUnsub: Unsubscribe | undefined;
     let onStatusUnsub: Unsubscribe | undefined;
 
-    return {
+    const proxy = {
         id: call.id,
         type: call.type,
         device_token: call.deviceToken,
         direction: call.direction,
-        status: call.status,
-        peer: { ...call.peer, muted: false },
 
         mute(): Promise<{ err: string | null }> {
             return new Promise((resolve) => {
@@ -186,7 +184,15 @@ export function CallOutgoingProxy(
             onStatusUnsub?.();
             onStatusUnsub = emitter.on("status", cb);
         },
-    };
+    } as CallOutgoing;
+
+    // Live getters — see CallActive.ts. `peer.muted` stays false until a transport exists.
+    Object.defineProperties(proxy, {
+        status: { get: () => call.status, enumerable: true },
+        peer: { get: () => ({ ...call.peer, muted: false }), enumerable: true },
+    });
+
+    return proxy;
 }
 
 function createTransport(mediaPlan: MediaPlan, mediaManager: MediaManager, deviceToken: string): ITransport {

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -63,9 +63,19 @@ export function CallOutgoingProxy(
 
         let transport: ITransport;
         if (preBuiltTransport && mediaPlan.type === "webRTC") {
+            // Defer marking `disposed` until handover succeeds. Otherwise a throw
+            // mid-await leaves preBuiltTransport orphaned (mic stream live, pc open)
+            // because the later dispose() short-circuits on the flag (B7).
+            try {
+                await preBuiltTransport.setAnswer(mediaPlan.sdp);
+                await preBuiltTransport.start();
+            } catch {
+                await preBuiltTransport.stop().catch(() => {});
+                disposed = true;
+                emitter.emit("ended");
+                return;
+            }
             disposed = true;
-            await preBuiltTransport.setAnswer(mediaPlan.sdp);
-            await preBuiltTransport.start();
             transport = preBuiltTransport;
         } else {
             await dispose();

--- a/src/modules/call/Offer.ts
+++ b/src/modules/call/Offer.ts
@@ -86,13 +86,11 @@ export function OfferProxy(
     let onEndUnsub: Unsubscribe | undefined;
     let onStatusUnsub: Unsubscribe | undefined;
 
-    return {
+    const proxy = {
         id: call.id,
         type: call.type,
         device_token: call.deviceToken,
         direction: call.direction,
-        status: call.status,
-        peer: { ...call.peer, muted: false },
 
         async accept(): Promise<{ call: CallActive; err: null } | { call: null; err: string }> {
             try {
@@ -143,5 +141,13 @@ export function OfferProxy(
             onStatusUnsub?.();
             onStatusUnsub = emitter.on("status", cb);
         },
-    };
+    } as Offer;
+
+    // Live getters — see CallActive.ts.
+    Object.defineProperties(proxy, {
+        status: { get: () => call.status, enumerable: true },
+        peer: { get: () => ({ ...call.peer, muted: false }), enumerable: true },
+    });
+
+    return proxy;
 }

--- a/src/modules/device/Call.ts
+++ b/src/modules/device/Call.ts
@@ -1,8 +1,8 @@
 import type { CallStats, ServerCallStats } from "@/modules/call/Stats";
-import type { DeviceSocket, MediaPlan } from "@/modules/device/WebSocket";
+import type { DeviceSocket, MediaPlan, ServerEvents } from "@/modules/device/WebSocket";
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
-import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 
 export type CallEvents = {
     status: [status: CallStatus];
@@ -71,48 +71,77 @@ export class Call extends EventEmitter<CallEvents> {
 
     /**
      * Subscribe to socket events scoped to this call.id. Aggregates raw
-     * `call:*` server events into the typed Call event stream.
+     * `call:*` server events into the typed Call event stream. The returned
+     * Unsubscribe removes every socket listener installed here; it is also
+     * invoked automatically when a terminal status event arrives so abandoned
+     * Calls do not leak listeners on the shared device socket (B2).
      */
-    wireSocket(socket: DeviceSocket): void {
-        socket.on("call:ringing", (id) => {
+    wireSocket(socket: DeviceSocket): Unsubscribe {
+        const unsubs: Array<() => void> = [];
+        let disposed = false;
+        const disposeAll = () => {
+            if (disposed) return;
+            disposed = true;
+            for (const u of unsubs) u();
+        };
+        // socket.io's typed Socket exposes a FallbackToUntypedListener that the
+        // compiler can't unify with our local E generic. Cast once via `unknown` to
+        // a narrowly-typed shape so the rest of bind stays fully typed.
+        type SocketLike = {
+            on<E extends keyof ServerEvents>(event: E, handler: ServerEvents[E]): unknown;
+            off<E extends keyof ServerEvents>(event: E, handler: ServerEvents[E]): unknown;
+        };
+        const s = socket as unknown as SocketLike;
+        const bind = <E extends keyof ServerEvents>(event: E, handler: ServerEvents[E]) => {
+            s.on(event, handler);
+            unsubs.push(() => s.off(event, handler));
+        };
+
+        bind("call:ringing", (id) => {
             if (id !== this.id) return;
             this.emit("ringing");
             this.emit("status", "RINGING");
         });
-        socket.on("call:ended", (id) => {
+        bind("call:ended", (id) => {
             if (id !== this.id) return;
             this.emit("ended");
             this.emit("status", "ENDED");
+            disposeAll();
         });
-        socket.on("call:accepted", (id) => {
+        bind("call:accepted", (id) => {
             if (id !== this.id) return;
             this.emit("accepted");
             this.emit("status", "ACTIVE");
         });
-        socket.on("call:answered", (id, mediaPlan) => {
+        bind("call:answered", (id, mediaPlan) => {
             if (id !== this.id) return;
             this.emit("answered", mediaPlan);
             this.emit("status", "ACTIVE");
         });
-        socket.on("call:unanswered", (id) => {
+        bind("call:unanswered", (id) => {
             if (id !== this.id) return;
             this.emit("unanswered");
             this.emit("status", "NOT_ANSWERED");
+            disposeAll();
         });
-        socket.on("call:rejected", (id) => {
+        bind("call:rejected", (id) => {
             if (id !== this.id) return;
             this.emit("rejected");
             this.emit("status", "REJECTED");
+            disposeAll();
         });
-        socket.on("call:failed", (id, err) => {
+        bind("call:failed", (id, err) => {
             if (id !== this.id) return;
             this.emit("failed", err);
             this.emit("status", "FAILED");
+            disposeAll();
         });
-        socket.on("call:stats", (id, stats) => {
+        bind("call:stats", (id, stats) => {
             if (id !== this.id) return;
             this.emit("serverStats", stats);
         });
+
+        return disposeAll;
     }
 
     /**

--- a/src/modules/device/Call.ts
+++ b/src/modules/device/Call.ts
@@ -150,10 +150,11 @@ export class Call extends EventEmitter<CallEvents> {
      * transport gathered before being wired so late listeners catch up.
      */
     wireTransport(transport: ITransport): void {
-        transport.on("statusChanged", (s) => {
-            this.emit("connectionStatus", s);
-            if (s === "disconnected") this.emit("ended");
-        });
+        // Forward connection status without inferring call termination from it.
+        // Transient transport drops (WS reconnect, brief WebRTC ICE disconnect) used
+        // to end the call here, which racy reconnects could fire. Call termination
+        // is now driven exclusively by the signaling `call:*` terminal events (B3).
+        transport.on("statusChanged", (s) => this.emit("connectionStatus", s));
         transport.on("peerMuted", (m) => this.emit("peerMuted", m));
         transport.on("statsChanged", (s) => this.emit("stats", s));
         transport.on("iceDiagnostics", (d) => this.emit("iceDiagnostics", d));

--- a/src/modules/device/Call.ts
+++ b/src/modules/device/Call.ts
@@ -140,6 +140,13 @@ export class Call extends EventEmitter<CallEvents> {
             if (id !== this.id) return;
             this.emit("serverStats", stats);
         });
+        // Relay (UNOFFICIAL) peer mute travels through the server: only WebRTC
+        // transports detect mute via track events. Wiring this here covers both
+        // transports uniformly (B5).
+        bind("call:peer:muted", (id, muted) => {
+            if (id !== this.id) return;
+            this.emit("peerMuted", muted);
+        });
 
         return disposeAll;
     }

--- a/src/test/call/CallActive.test.ts
+++ b/src/test/call/CallActive.test.ts
@@ -73,6 +73,39 @@ describe("CallActive", () => {
             expect(active.connection_status).toBe("connected");
         });
 
+        it("status reflects later mutations of call.status", () => {
+            const call = makeCall();
+            const transport = makeMockTransport();
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, transport, mm as never, { onEnd: vi.fn() });
+
+            expect(active.status).toBe("ACTIVE");
+            call.status = "ENDED";
+            expect(active.status).toBe("ENDED");
+        });
+
+        it("connection_status reflects later mutations of transport.status", () => {
+            const call = makeCall();
+            const transport = makeMockTransport({ status: "connecting" } as Partial<ITransport>);
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, transport, mm as never, { onEnd: vi.fn() });
+
+            expect(active.connection_status).toBe("connecting");
+            transport.status = "connected";
+            expect(active.connection_status).toBe("connected");
+        });
+
+        it("peer.muted reflects later mutations of transport.peerMuted", () => {
+            const call = makeCall();
+            const transport = makeMockTransport({ peerMuted: false } as Partial<ITransport>);
+            const mm = makeMockMediaManager();
+            const active = CallActiveProxy(call, transport, mm as never, { onEnd: vi.fn() });
+
+            expect(active.peer.muted).toBe(false);
+            transport.peerMuted = true;
+            expect(active.peer.muted).toBe(true);
+        });
+
         it("audio_analyser reads transport.audioAnalyser", async () => {
             const call = makeCall();
             

--- a/src/test/call/CallOutgoing.test.ts
+++ b/src/test/call/CallOutgoing.test.ts
@@ -53,6 +53,19 @@ function makeMockPreBuiltTransport() {
 }
 
 describe("CallOutgoing", () => {
+    describe("getters", () => {
+        it("status reflects later mutations of call.status", () => {
+            const call = makeCall();
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const outgoing = CallOutgoingProxy(call, socket, mm as never);
+
+            expect(outgoing.status).toBe("RINGING");
+            call.status = "ACTIVE";
+            expect(outgoing.status).toBe("ACTIVE");
+        });
+    });
+
     describe("terminal cleanup (mic release pre-answer)", () => {
         it("stops preBuiltTransport on bus 'rejected'", () => {
             const call = makeCall();

--- a/src/test/call/CallOutgoing.test.ts
+++ b/src/test/call/CallOutgoing.test.ts
@@ -173,7 +173,7 @@ describe("CallOutgoing", () => {
 
         it("no preBuiltTransport — terminal events do not throw", () => {
             const call = makeCall();
-            
+
             const socket = makeMockSocket();
             const mm = makeMockMediaManager();
 
@@ -182,6 +182,42 @@ describe("CallOutgoing", () => {
             expect(() => call.emit("ended")).not.toThrow();
             expect(() => call.emit("rejected")).not.toThrow();
             expect(() => call.emit("unanswered")).not.toThrow();
+        });
+
+        it("setAnswer throw during handover stops preBuiltTransport and emits 'ended' (B7)", async () => {
+            const call = makeCall();
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+            preBuilt.setAnswer = vi.fn().mockRejectedValue(new Error("boom"));
+
+            const outgoing = CallOutgoingProxy(call, socket, mm as never, preBuilt);
+            const endedCb = vi.fn();
+            outgoing.on("ended", endedCb);
+
+            call.emit("answered", { type: "webRTC", sdp: "answer-sdp" });
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+            expect(endedCb).toHaveBeenCalledOnce();
+        });
+
+        it("start() throw during handover stops preBuiltTransport and emits 'ended' (B7)", async () => {
+            const call = makeCall();
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+            preBuilt.start = vi.fn().mockRejectedValue(new Error("boom"));
+
+            const outgoing = CallOutgoingProxy(call, socket, mm as never, preBuilt);
+            const endedCb = vi.fn();
+            outgoing.on("ended", endedCb);
+
+            call.emit("answered", { type: "webRTC", sdp: "answer-sdp" });
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+            expect(endedCb).toHaveBeenCalledOnce();
         });
     });
 

--- a/src/test/call/Offer.test.ts
+++ b/src/test/call/Offer.test.ts
@@ -48,9 +48,18 @@ describe("Offer", () => {
 
         it("peer spreads call.peer and adds muted: false", () => {
             const call = makeCall();
-            
+
             const offer = OfferProxy(call, { onAccept: vi.fn(), onReject: vi.fn() });
             expect(offer.peer).toEqual({ ...peer, muted: false });
+        });
+
+        it("status reflects later mutations of call.status", () => {
+            const call = makeCall();
+            const offer = OfferProxy(call, { onAccept: vi.fn(), onReject: vi.fn() });
+
+            expect(offer.status).toBe("CALLING");
+            call.status = "ACTIVE";
+            expect(offer.status).toBe("ACTIVE");
         });
     });
 

--- a/src/test/device/Call.wire.test.ts
+++ b/src/test/device/Call.wire.test.ts
@@ -225,6 +225,84 @@ describe("Call.wireSocket", () => {
 
         expect(cb).not.toHaveBeenCalled();
     });
+
+    it("returned Unsubscribe removes all socket listeners", () => {
+        const call = makeCall();
+        const socket = makeMockSocket();
+        const unsub = call.wireSocket(socket);
+        const ringingCb = vi.fn();
+        call.on("ringing", ringingCb);
+
+        unsub();
+        emitSocket(socket, "call:ringing", call.id);
+
+        expect(ringingCb).not.toHaveBeenCalled();
+    });
+
+    it("auto-disposes socket listeners after terminal call:ended (B2)", () => {
+        const call = makeCall();
+        const socket = makeMockSocket();
+        call.wireSocket(socket);
+        const ringingCb = vi.fn();
+        call.on("ringing", ringingCb);
+
+        emitSocket(socket, "call:ended", call.id);
+        emitSocket(socket, "call:ringing", call.id);
+
+        expect(ringingCb).not.toHaveBeenCalled();
+    });
+
+    it("auto-disposes socket listeners after terminal call:rejected (B2)", () => {
+        const call = makeCall();
+        const socket = makeMockSocket();
+        call.wireSocket(socket);
+        const ringingCb = vi.fn();
+        call.on("ringing", ringingCb);
+
+        emitSocket(socket, "call:rejected", call.id);
+        emitSocket(socket, "call:ringing", call.id);
+
+        expect(ringingCb).not.toHaveBeenCalled();
+    });
+
+    it("auto-disposes socket listeners after terminal call:unanswered (B2)", () => {
+        const call = makeCall();
+        const socket = makeMockSocket();
+        call.wireSocket(socket);
+        const ringingCb = vi.fn();
+        call.on("ringing", ringingCb);
+
+        emitSocket(socket, "call:unanswered", call.id);
+        emitSocket(socket, "call:ringing", call.id);
+
+        expect(ringingCb).not.toHaveBeenCalled();
+    });
+
+    it("auto-disposes socket listeners after terminal call:failed (B2)", () => {
+        const call = makeCall();
+        const socket = makeMockSocket();
+        call.wireSocket(socket);
+        const ringingCb = vi.fn();
+        call.on("ringing", ringingCb);
+
+        emitSocket(socket, "call:failed", call.id, "boom");
+        emitSocket(socket, "call:ringing", call.id);
+
+        expect(ringingCb).not.toHaveBeenCalled();
+    });
+
+    it("ignores cross-call terminal events when filtering by id (no premature dispose)", () => {
+        const call = makeCall("call-1");
+        const socket = makeMockSocket();
+        call.wireSocket(socket);
+        const ringingCb = vi.fn();
+        call.on("ringing", ringingCb);
+
+        emitSocket(socket, "call:ended", "other-call");
+        emitSocket(socket, "call:ringing", call.id);
+
+        expect(ringingCb).toHaveBeenCalledOnce();
+    });
 });
 
 describe("Call.wireTransport", () => {

--- a/src/test/device/Call.wire.test.ts
+++ b/src/test/device/Call.wire.test.ts
@@ -226,6 +226,32 @@ describe("Call.wireSocket", () => {
         expect(cb).not.toHaveBeenCalled();
     });
 
+    it("call:peer:muted emits peerMuted with server-reported value (B5)", () => {
+        const call = makeCall();
+        const socket = makeMockSocket();
+        call.wireSocket(socket);
+        const cb = vi.fn();
+        call.on("peerMuted", cb);
+
+        emitSocket(socket, "call:peer:muted", call.id, true);
+        emitSocket(socket, "call:peer:muted", call.id, false);
+
+        expect(cb).toHaveBeenNthCalledWith(1, true);
+        expect(cb).toHaveBeenNthCalledWith(2, false);
+    });
+
+    it("ignores call:peer:muted for different call id", () => {
+        const call = makeCall("call-1");
+        const socket = makeMockSocket();
+        call.wireSocket(socket);
+        const cb = vi.fn();
+        call.on("peerMuted", cb);
+
+        emitSocket(socket, "call:peer:muted", "other-call", true);
+
+        expect(cb).not.toHaveBeenCalled();
+    });
+
     it("returned Unsubscribe removes all socket listeners", () => {
         const call = makeCall();
         const socket = makeMockSocket();

--- a/src/test/device/Call.wire.test.ts
+++ b/src/test/device/Call.wire.test.ts
@@ -333,7 +333,7 @@ describe("Call.wireTransport", () => {
         expect(endedCb).not.toHaveBeenCalled();
     });
 
-    it("transport statusChanged 'disconnected' → emits connectionStatus AND 'ended'", () => {
+    it("transport statusChanged 'disconnected' → emits connectionStatus but NOT 'ended' (B3)", () => {
         const call = makeCall();
         const transport = makeMockTransport();
         const connectionCb = vi.fn();
@@ -345,7 +345,7 @@ describe("Call.wireTransport", () => {
         (transport as unknown as EventEmitter<TransportEvents>).emit("statusChanged", "disconnected");
 
         expect(connectionCb).toHaveBeenCalledWith("disconnected");
-        expect(endedCb).toHaveBeenCalledOnce();
+        expect(endedCb).not.toHaveBeenCalled();
     });
 
     it("transport peerMuted → emits peerMuted", () => {

--- a/src/test/device/DeviceConnection.test.ts
+++ b/src/test/device/DeviceConnection.test.ts
@@ -22,9 +22,22 @@ const { makeSocket, getSocket } = vi.hoisted(() => {
                 listeners.get(event)?.push(cb);
                 return this;
             },
+            off(event: string, cb: SocketListener) {
+                const arr = listeners.get(event);
+                if (!arr) return this;
+                listeners.set(
+                    event,
+                    arr.filter((fn) => fn !== cb),
+                );
+                return this;
+            },
             /** Simulate a message arriving from the server */
             receive(event: string, ...args: unknown[]) {
                 for (const cb of listeners.get(event) ?? []) cb(...args);
+            },
+            /** Test helper — count listeners for an event */
+            listenerCount(event: string): number {
+                return listeners.get(event)?.length ?? 0;
             },
         };
         _last = s;


### PR DESCRIPTION
## Summary

Sprint A of the call/transport refactor. Five regressions found during architecture review, each shipped as its own commit with a regression test.

| Bug | Commit | What |
|---|---|---|
| B1 | `4a6c81b` | Proxy `status` / `connection_status` / `peer.muted` were captured by value at proxy creation. Now live getters reading from `Call` / `ITransport`. |
| B2 | `ef47542` | `Call.wireSocket` left 8 listeners per call on the shared device socket forever. Now returns `Unsubscribe` and auto-disposes on any terminal `call:*` event. |
| B3 | `1ca9303` | Transport `statusChanged → "disconnected"` ended the call. Transient WS reconnects (and brief WebRTC ICE blips) would terminate active calls. Call lifecycle is now driven only by signaling `call:*` terminal events. |
| B5 | `bab14e3` | Server's `call:peer:muted` event was declared in `ServerEvents` but never subscribed. Relay (UNOFFICIAL) calls had no peer-mute signal. Now wired uniformly across both transports. |
| B7 | `c4f6713` | `CallOutgoing` set `disposed = true` before `await preBuiltTransport.setAnswer(...) / .start()`. A throw mid-handover orphaned the pc + mic. Now guarded with try/catch that force-stops the transport and emits `ended`. |

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 198/198 passing (was 183; +15 new regression tests)
- [x] `pnpm build` — clean
- [ ] Smoke test in a consumer app: verify call survives a brief network blip, verify `peer.muted` updates after server signals, verify peer mute lands for relay calls

## Compatibility

No public type changes. `Call.wireSocket` return type widened from `void` to `Unsubscribe` — callers ignoring the return value are unaffected.

## What's not in this PR

Deferred to later sprints:
- B4 (signaling auth hardcoded to `"official"`)
- B6 (worklet bootstrap is eager and uses jsDelivr CDN)
- B8 (`EventEmitter.emit` has no try/catch per listener)
- ITransport leakage of WebRTC-only fields (Sprint C / plan C composition)
- Proxy boilerplate (Sprint B — `forwardEvents` utility)
- `Call` state machine + central `CallRouter` (Sprint B)