### PR TITLE
refactor(call): Sprint B — forwardEvents utility + table-driven Call transitions + proxy slimming

### DIFF
--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -5,6 +5,7 @@ import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagn
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
+import { forwardEvents } from "@/modules/shared/forwardEvents";
 
 export type CallActiveEvents = {
     error: [err: string];
@@ -68,6 +69,15 @@ export function CallActiveProxy(
         return Promise.resolve(transport.stop()).catch(() => {});
     };
 
+    // Pure 1:1 relays — kept type-checked via the typed mapping.
+    forwardEvents(call, emitter, {
+        stats: "stats",
+        serverStats: "serverStats",
+        connectionStatus: "connectionStatus",
+        status: "status",
+    });
+
+    // Side-effecting subscribers (dispose, rename, buffered replay) stay inline.
     call.on("failed", (err) => {
         emitter.emit("error", err);
         void dispose();
@@ -79,18 +89,6 @@ export function CallActiveProxy(
     call.on("ended", () => {
         emitter.emit("ended");
         void dispose();
-    });
-    call.on("stats", (stats) => {
-        emitter.emit("stats", stats);
-    });
-    call.on("serverStats", (stats) => {
-        emitter.emit("serverStats", stats);
-    });
-    call.on("connectionStatus", (status) => {
-        emitter.emit("connectionStatus", status);
-    });
-    call.on("status", (status) => {
-        emitter.emit("status", status);
     });
     call.on("iceDiagnostics", (diag) => {
         lastIceDiagnostics = diag;

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -8,6 +8,7 @@ import type { MediaManager } from "@/modules/media/MediaManager";
 import { WebRTCTransport } from "@/modules/media/WebRTC";
 import { WebsocketTransport } from "@/modules/media/WebSocket";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
+import { forwardEvents } from "@/modules/shared/forwardEvents";
 
 export type CallOutgoingEvents = {
     peerAccept: [call: CallActive];
@@ -96,6 +97,14 @@ export function CallOutgoingProxy(
         });
         emitter.emit("peerAccept", active);
     });
+    // Pure 1:1 relays.
+    forwardEvents(call, emitter, {
+        status: "status",
+        iceDiagnostics: "iceDiagnostics",
+        connectivityIssue: "connectivityIssue",
+    });
+
+    // Side-effecting (dispose, rename) stay inline.
     call.on("rejected", () => {
         emitter.emit("peerReject");
         void dispose();
@@ -107,15 +116,6 @@ export function CallOutgoingProxy(
     call.on("ended", () => {
         emitter.emit("ended");
         void dispose();
-    });
-    call.on("status", (status) => {
-        emitter.emit("status", status);
-    });
-    call.on("iceDiagnostics", (diag) => {
-        emitter.emit("iceDiagnostics", diag);
-    });
-    call.on("connectivityIssue", (issue) => {
-        emitter.emit("connectivityIssue", issue);
     });
 
     let onPeerAcceptUnsub: Unsubscribe | undefined;

--- a/src/modules/call/Offer.ts
+++ b/src/modules/call/Offer.ts
@@ -3,6 +3,7 @@ import type { CallPeer } from "@/modules/call/Peer";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
+import { forwardEvents } from "@/modules/shared/forwardEvents";
 
 export type OfferEvents = {
     acceptedElsewhere: [];
@@ -76,9 +77,13 @@ export function OfferProxy(
             dispose();
         }),
     );
-    callUnsubs.push(call.on("status", (status) => emitter.emit("status", status)));
-    callUnsubs.push(call.on("iceDiagnostics", (diag) => emitter.emit("iceDiagnostics", diag)));
-    callUnsubs.push(call.on("connectivityIssue", (issue) => emitter.emit("connectivityIssue", issue)));
+    callUnsubs.push(
+        forwardEvents(call, emitter, {
+            status: "status",
+            iceDiagnostics: "iceDiagnostics",
+            connectivityIssue: "connectivityIssue",
+        }),
+    );
 
     let onAcceptedElsewhereUnsub: Unsubscribe | undefined;
     let onRejectedElsewhereUnsub: Unsubscribe | undefined;

--- a/src/modules/device/Call.ts
+++ b/src/modules/device/Call.ts
@@ -33,41 +33,23 @@ export class Call extends EventEmitter<CallEvents> {
         super();
     }
 
-    accept(): boolean {
-        if (!["RINGING", "CALLING"].includes(this.status)) return false;
-        this.status = "ACTIVE";
+    // Status-transition table. Each entry guards a transition by predicate on the
+    // current status and declares the target. Behavior matches the historical
+    // ad-hoc methods exactly — emitting `status` on transition stays the
+    // responsibility of `wireSocket`'s server-event handlers (no double-emit).
+    private transition(name: TransitionName): boolean {
+        const def = TRANSITIONS[name];
+        if (!def.allow(this.status)) return false;
+        this.status = def.to;
         return true;
     }
 
-    reject(): boolean {
-        if (this.status !== "ACTIVE") return false;
-        this.status = "REJECTED";
-        return true;
-    }
-
-    cancel(): boolean {
-        if (this.status === "ACTIVE") return false;
-        this.status = "ENDED";
-        return true;
-    }
-
-    end(): boolean {
-        if (this.status !== "ACTIVE") return false;
-        this.status = "ENDED";
-        return true;
-    }
-
-    timeout() {
-        if (!["RINGING", "CALLING"].includes(this.status)) return false;
-        this.status = "NOT_ANSWERED";
-        return true;
-    }
-
-    fail() {
-        if (!["ACTIVE"].includes(this.status)) return false;
-        this.status = "FAILED";
-        return true;
-    }
+    accept(): boolean { return this.transition("accept"); }
+    reject(): boolean { return this.transition("reject"); }
+    cancel(): boolean { return this.transition("cancel"); }
+    end(): boolean { return this.transition("end"); }
+    timeout(): boolean { return this.transition("timeout"); }
+    fail(): boolean { return this.transition("fail"); }
 
     /**
      * Subscribe to socket events scoped to this call.id. Aggregates raw
@@ -187,6 +169,17 @@ export type CallStatus =
     | "REJECTED"
     | "FAILED"
     | "DISCONNECTED";
+
+type TransitionName = "accept" | "reject" | "cancel" | "end" | "timeout" | "fail";
+
+const TRANSITIONS: Record<TransitionName, { allow: (s: CallStatus) => boolean; to: CallStatus }> = {
+    accept:  { allow: (s) => s === "RINGING" || s === "CALLING", to: "ACTIVE" },
+    reject:  { allow: (s) => s === "ACTIVE", to: "REJECTED" },
+    cancel:  { allow: (s) => s !== "ACTIVE", to: "ENDED" },
+    end:     { allow: (s) => s === "ACTIVE", to: "ENDED" },
+    timeout: { allow: (s) => s === "RINGING" || s === "CALLING", to: "NOT_ANSWERED" },
+    fail:    { allow: (s) => s === "ACTIVE", to: "FAILED" },
+};
 
 export type CallType = "OFFICIAL" | "UNOFFICIAL";
 

--- a/src/modules/shared/forwardEvents.ts
+++ b/src/modules/shared/forwardEvents.ts
@@ -1,0 +1,51 @@
+import type { EventEmitter, Unsubscribe } from "@/modules/shared/EventEmitter";
+
+type EventMap = { [k: string]: unknown[] };
+
+type MappedEntry<S extends EventMap, K extends keyof S, D extends EventMap> = {
+    to: keyof D;
+    map: (...args: S[K]) => D[keyof D];
+};
+
+export type Forwarding<S extends EventMap, D extends EventMap> = {
+    [K in keyof S]?: keyof D | MappedEntry<S, K, D>;
+};
+
+/**
+ * Maps a source-event name to either:
+ *   - a destination-event name (1:1 forward, same payload), or
+ *   - a `{ to, map }` pair where `map` transforms the payload before re-emit.
+ *
+ * Returns an Unsubscribe that detaches every forwarded listener at once.
+ *
+ * @example
+ *   forwardEvents(call, emitter, {
+ *     ended: "ended",
+ *     peerMuted: { to: "peerMute", map: (m) => [m ? "on" : "off"] },
+ *   });
+ */
+export function forwardEvents<S extends EventMap, D extends EventMap>(
+    source: EventEmitter<S>,
+    dest: EventEmitter<D>,
+    mapping: Forwarding<S, D>,
+): Unsubscribe {
+    const unsubs: Unsubscribe[] = [];
+    for (const key of Object.keys(mapping) as (keyof S)[]) {
+        const entry = mapping[key];
+        if (entry === undefined) continue;
+        const mapped = isMappedEntry(entry) ? entry : null;
+        const targetKey = (mapped ? mapped.to : entry) as keyof D;
+        const listener = ((...args: S[typeof key]) => {
+            const out = (mapped ? mapped.map(...args) : args) as D[keyof D];
+            dest.emit(targetKey, ...out);
+        }) as Parameters<EventEmitter<S>["on"]>[1];
+        unsubs.push(source.on(key, listener));
+    }
+    return () => {
+        for (const u of unsubs) u();
+    };
+}
+
+function isMappedEntry(entry: unknown): entry is { to: PropertyKey; map: (...args: unknown[]) => unknown[] } {
+    return typeof entry === "object" && entry !== null && "to" in entry;
+}

--- a/src/test/shared/forwardEvents.test.ts
+++ b/src/test/shared/forwardEvents.test.ts
@@ -1,0 +1,87 @@
+import { EventEmitter } from "@/modules/shared/EventEmitter";
+import { forwardEvents } from "@/modules/shared/forwardEvents";
+import { describe, expect, it, vi } from "vitest";
+
+type SourceEvents = {
+    ping: [n: number];
+    note: [text: string];
+    muted: [m: boolean];
+    unused: [];
+};
+
+type DestEvents = {
+    pong: [n: number];
+    label: [text: string];
+    peerMute: [state: "on" | "off"];
+};
+
+describe("forwardEvents", () => {
+    it("forwards a source event 1:1 to a destination event with same payload", () => {
+        const src = new EventEmitter<SourceEvents>();
+        const dst = new EventEmitter<DestEvents>();
+        const cb = vi.fn();
+        dst.on("pong", cb);
+
+        forwardEvents(src, dst, { ping: "pong" });
+        src.emit("ping", 7);
+
+        expect(cb).toHaveBeenCalledWith(7);
+    });
+
+    it("supports a map function that rewrites payload shape", () => {
+        const src = new EventEmitter<SourceEvents>();
+        const dst = new EventEmitter<DestEvents>();
+        const cb = vi.fn();
+        dst.on("peerMute", cb);
+
+        forwardEvents(src, dst, {
+            muted: { to: "peerMute", map: (m): ["on" | "off"] => [m ? "on" : "off"] },
+        });
+        src.emit("muted", true);
+        src.emit("muted", false);
+
+        expect(cb).toHaveBeenNthCalledWith(1, "on");
+        expect(cb).toHaveBeenNthCalledWith(2, "off");
+    });
+
+    it("does not subscribe to source events absent from the mapping", () => {
+        const src = new EventEmitter<SourceEvents>();
+        const dst = new EventEmitter<DestEvents>();
+        const cb = vi.fn();
+        dst.on("label", cb);
+
+        forwardEvents(src, dst, { ping: "pong" });
+        src.emit("note", "hello");
+
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("returned Unsubscribe detaches every forwarded listener", () => {
+        const src = new EventEmitter<SourceEvents>();
+        const dst = new EventEmitter<DestEvents>();
+        const cb = vi.fn();
+        dst.on("pong", cb);
+
+        const unsub = forwardEvents(src, dst, { ping: "pong" });
+        unsub();
+        src.emit("ping", 1);
+
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("multiple mappings forward independently", () => {
+        const src = new EventEmitter<SourceEvents>();
+        const dst = new EventEmitter<DestEvents>();
+        const pongCb = vi.fn();
+        const labelCb = vi.fn();
+        dst.on("pong", pongCb);
+        dst.on("label", labelCb);
+
+        forwardEvents(src, dst, { ping: "pong", note: "label" });
+        src.emit("ping", 9);
+        src.emit("note", "hi");
+
+        expect(pongCb).toHaveBeenCalledWith(9);
+        expect(labelCb).toHaveBeenCalledWith("hi");
+    });
+});


### PR DESCRIPTION
## Summary

Sprint B of the call/transport refactor. Foundational primitives that reduce per-event-add cost and prepare the ground for Sprint C (transport composition / plan C).

**Base:** stacked on `refactor/sprint-a` (PR #25). Once Sprint A merges, this PR's diff against `main` will collapse to just the Sprint B changes.

| Step | Commit | What |
|---|---|---|
| B.1 | `5060cb9` | New `forwardEvents(src, dst, mapping)` utility in `modules/shared/`. Replaces manual `src.on(x, (...a) => dst.emit(y, ...a))` blocks. Returns one `Unsubscribe` that detaches every forwarded listener. |
| B.3 | `6f5947b` | `Call` status transitions now go through a single table-driven `transition()` helper. Six ad-hoc guard blocks collapse to six one-liners + one `TRANSITIONS` constant. Behavior preserved exactly. |
| B.2 | `c795a2f` | Adopt `forwardEvents` for pure 1:1 relays in `CallActive`, `CallOutgoing`, `Offer`. Side-effecting subscribers (dispose, rename, buffered replay) stay inline. |

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 203/203 passing (+5 new `forwardEvents` unit tests, no regressions in existing proxy specs)
- [x] `pnpm build` — clean
- [ ] Smoke test in a consumer app: verify event delivery on Offer / CallOutgoing / CallActive is unchanged

## Compatibility

No public type changes. No behavior changes. Pure structural simplification.

## What's deferred

- **B.4 (CallRouter)** — moved to Sprint C. Implementing it requires reshaping `DeviceConnection`, which overlaps with the transport-composition work in plan C. Doing them together keeps `DeviceConnection` from being touched twice.
- B4, B6, B8 (still in backlog from Sprint A scope decisions).

## Why these belong together

Sprint C (transport composition) will introduce `StatsTicker`, `RTCConnection`, `RTCAudioPipe`, `RTCStatsAdapter`, `WSConnection`, `WSAudioPipe`, `WSStatsAdapter` — each is its own EventEmitter and needs its events relayed up through the orchestrator. `forwardEvents` collapses those relays from ~40 manual lines to a few mappings. Landing it now means Sprint C ships smaller and clearer.