### PR TITLE
Sprint D: deprecation warnings, lazy worklets, vendored libsamplerate

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     },
     "packageManager": "pnpm@10.7.1",
     "devDependencies": {
+        "@alexanderolsen/libsamplerate-js": "2.1.2",
         "@biomejs/biome": "1.9.4",
         "@types/node": "^22.14.0",
         "@vitest/coverage-v8": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^4.8.1
         version: 4.8.1
     devDependencies:
+      '@alexanderolsen/libsamplerate-js':
+        specifier: 2.1.2
+        version: 2.1.2
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
@@ -56,6 +59,9 @@ importers:
         version: 4.1.2(@types/node@22.15.3)(happy-dom@20.8.9)(vite@6.3.5(@types/node@22.15.3))
 
 packages:
+
+  '@alexanderolsen/libsamplerate-js@2.1.2':
+    resolution: {integrity: sha512-pIXQDX/DZIgz6pKInUddDd6Tnq/s2E9g4ZITkKX60kxM/nAuZcxYa/z0y/jwJbjyp/oKe+8/qHLSqMzQ18xSiQ==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1572,6 +1578,8 @@ packages:
     engines: {node: '>=6'}
 
 snapshots:
+
+  '@alexanderolsen/libsamplerate-js@2.1.2': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:

--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -4,6 +4,7 @@ import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
+import { warnDeprecated } from "@/modules/shared/deprecation";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 import { forwardEvents } from "@/modules/shared/forwardEvents";
 
@@ -146,42 +147,49 @@ export function CallActiveProxy(
 
         /** @deprecated Use `on("error", callback)` instead. */
         onError(callback: (err: string) => void): void {
+            warnDeprecated("CallActive.onError", 'use `active.on("error", cb)` instead.');
             onErrorUnsub?.();
             onErrorUnsub = emitter.on("error", callback);
         },
 
         /** @deprecated Use `on("peerMute", callback)` instead. */
         onPeerMute(callback: () => void): void {
+            warnDeprecated("CallActive.onPeerMute", 'use `active.on("peerMute", cb)` instead.');
             onPeerMuteUnsub?.();
             onPeerMuteUnsub = emitter.on("peerMute", callback);
         },
 
         /** @deprecated Use `on("peerUnmute", callback)` instead. */
         onPeerUnmute(callback: () => void): void {
+            warnDeprecated("CallActive.onPeerUnmute", 'use `active.on("peerUnmute", cb)` instead.');
             onPeerUnmuteUnsub?.();
             onPeerUnmuteUnsub = emitter.on("peerUnmute", callback);
         },
 
         /** @deprecated Use `on("ended", callback)` instead. */
         onEnd(callback: () => void): void {
+            warnDeprecated("CallActive.onEnd", 'use `active.on("ended", cb)` instead.');
             onEndUnsub?.();
             onEndUnsub = emitter.on("ended", callback);
         },
 
         /** @deprecated Use `on("stats", callback)` instead. */
         onStats(callback: (stats: CallStats) => void): void {
+            warnDeprecated("CallActive.onStats", 'use `active.on("stats", cb)` instead.');
             onStatsUnsub?.();
             onStatsUnsub = emitter.on("stats", callback);
         },
 
         /** @deprecated Use `on("connectionStatus", callback)` instead. */
         onConnectionStatus(callback: (status: TransportStatus) => void): void {
+            warnDeprecated("CallActive.onConnectionStatus", 'use `active.on("connectionStatus", cb)` instead.');
             onConnectionStatusUnsub?.();
             onConnectionStatusUnsub = emitter.on("connectionStatus", callback);
         },
 
         /** @deprecated Use `on("status", callback)` instead. */
         onStatus(cb: (status: CallStatus) => void): void {
+            warnDeprecated("CallActive.onStatus", 'use `active.on("status", cb)` instead.');
             onStatusUnsub?.();
             onStatusUnsub = emitter.on("status", cb);
         },

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -7,6 +7,7 @@ import type { ITransport } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { WebRTCTransport } from "@/modules/media/WebRTC";
 import { WebsocketTransport } from "@/modules/media/WebSocket";
+import { warnDeprecated } from "@/modules/shared/deprecation";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 import { forwardEvents } from "@/modules/shared/forwardEvents";
 
@@ -167,30 +168,35 @@ export function CallOutgoingProxy(
 
         /** @deprecated Use `on("peerAccept", callback)` instead. */
         onPeerAccept(callback: (call: CallActive) => void): void {
+            warnDeprecated("CallOutgoing.onPeerAccept", 'use `outgoing.on("peerAccept", cb)` instead.');
             onPeerAcceptUnsub?.();
             onPeerAcceptUnsub = emitter.on("peerAccept", callback);
         },
 
         /** @deprecated Use `on("peerReject", callback)` instead. */
         onPeerReject(callback: () => void): void {
+            warnDeprecated("CallOutgoing.onPeerReject", 'use `outgoing.on("peerReject", cb)` instead.');
             onPeerRejectUnsub?.();
             onPeerRejectUnsub = emitter.on("peerReject", callback);
         },
 
         /** @deprecated Use `on("unanswered", callback)` instead. */
         onUnanswered(callback: () => void): void {
+            warnDeprecated("CallOutgoing.onUnanswered", 'use `outgoing.on("unanswered", cb)` instead.');
             onUnansweredUnsub?.();
             onUnansweredUnsub = emitter.on("unanswered", callback);
         },
 
         /** @deprecated Use `on("ended", callback)` instead. */
         onEnd(callback: () => void): void {
+            warnDeprecated("CallOutgoing.onEnd", 'use `outgoing.on("ended", cb)` instead.');
             onEndUnsub?.();
             onEndUnsub = emitter.on("ended", callback);
         },
 
         /** @deprecated Use `on("status", callback)` instead. */
         onStatus(cb: (status: CallStatus) => void): void {
+            warnDeprecated("CallOutgoing.onStatus", 'use `outgoing.on("status", cb)` instead.');
             onStatusUnsub?.();
             onStatusUnsub = emitter.on("status", cb);
         },

--- a/src/modules/call/Offer.ts
+++ b/src/modules/call/Offer.ts
@@ -2,6 +2,7 @@ import type { CallActive } from "@/modules/call/CallActive";
 import type { CallPeer } from "@/modules/call/Peer";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
+import { warnDeprecated } from "@/modules/shared/deprecation";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 import { forwardEvents } from "@/modules/shared/forwardEvents";
 
@@ -119,30 +120,35 @@ export function OfferProxy(
 
         /** @deprecated Use `on("acceptedElsewhere", callback)` instead. */
         onAcceptedElsewhere(callback: () => void): void {
+            warnDeprecated("Offer.onAcceptedElsewhere", 'use `offer.on("acceptedElsewhere", cb)` instead.');
             onAcceptedElsewhereUnsub?.();
             onAcceptedElsewhereUnsub = emitter.on("acceptedElsewhere", callback);
         },
 
         /** @deprecated Use `on("rejectedElsewhere", callback)` instead. */
         onRejectedElsewhere(callback: () => void): void {
+            warnDeprecated("Offer.onRejectedElsewhere", 'use `offer.on("rejectedElsewhere", cb)` instead.');
             onRejectedElsewhereUnsub?.();
             onRejectedElsewhereUnsub = emitter.on("rejectedElsewhere", callback);
         },
 
         /** @deprecated Use `on("unanswered", callback)` instead. */
         onUnanswered(cb: () => void): void {
+            warnDeprecated("Offer.onUnanswered", 'use `offer.on("unanswered", cb)` instead.');
             onUnansweredUnsub?.();
             onUnansweredUnsub = emitter.on("unanswered", cb);
         },
 
         /** @deprecated Use `on("ended", callback)` instead. */
         onEnd(cb: () => void): void {
+            warnDeprecated("Offer.onEnd", 'use `offer.on("ended", cb)` instead.');
             onEndUnsub?.();
             onEndUnsub = emitter.on("ended", cb);
         },
 
         /** @deprecated Use `on("status", callback)` instead. */
         onStatus(cb: (status: CallStatus) => void): void {
+            warnDeprecated("Offer.onStatus", 'use `offer.on("status", cb)` instead.');
             onStatusUnsub?.();
             onStatusUnsub = emitter.on("status", cb);
         },

--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -11,6 +11,7 @@ import type { IceConfig } from "@/modules/media/ICEDiagnostics";
 import type { MediaManager } from "@/modules/media/MediaManager";
 import { WebRTCTransport } from "@/modules/media/WebRTC";
 import { WebsocketTransport } from "@/modules/media/WebSocket";
+import { warnDeprecated } from "@/modules/shared/deprecation";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 import type { AxiosInstance } from "axios";
 import axios from "axios";
@@ -200,6 +201,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     /** @deprecated Use `on("statusChanged", callback)` instead. */
     onStatus(cb: (status: DeviceStatus) => void): () => void {
+        warnDeprecated("Device.onStatus", 'use `device.on("statusChanged", cb)` instead.');
         this._onStatusUnsub?.();
         this._onStatusUnsub = this.on("statusChanged", cb);
         return this._onStatusUnsub;
@@ -207,6 +209,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     /** @deprecated Use `on("qrCodeChanged", callback)` instead. */
     onQRCode(cb: (qrcode?: string) => void): () => void {
+        warnDeprecated("Device.onQRCode", 'use `device.on("qrCodeChanged", cb)` instead.');
         this._onQRCodeUnsub?.();
         this._onQRCodeUnsub = this.on("qrCodeChanged", cb);
         return this._onQRCodeUnsub;
@@ -214,6 +217,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     /** @deprecated Use `on("contactChanged", callback)` instead. */
     onContact(cb: (contact?: Contact) => void): () => void {
+        warnDeprecated("Device.onContact", 'use `device.on("contactChanged", cb)` instead.');
         this._onContactUnsub?.();
         this._onContactUnsub = this.on("contactChanged", cb);
         return this._onContactUnsub;

--- a/src/modules/device/DeviceProxy.ts
+++ b/src/modules/device/DeviceProxy.ts
@@ -2,6 +2,7 @@ import type { Contact, DeviceStatus } from "@/modules/device/Device";
 import type { DeviceConnection, DeviceEvents } from "@/modules/device/DeviceConnection";
 import type { Device } from "@/modules/device/DeviceConnection";
 import type { Unsubscribe } from "@/modules/shared/EventEmitter";
+import { warnDeprecated } from "@/modules/shared/deprecation";
 
 export function DeviceProxy(conn: DeviceConnection): Device {
     return {
@@ -16,14 +17,17 @@ export function DeviceProxy(conn: DeviceConnection): Device {
         },
 
         onStatus(cb: (status: DeviceStatus) => void): Unsubscribe {
+            warnDeprecated("Device.onStatus", 'use `device.on("statusChanged", cb)` instead.');
             return conn.on("statusChanged", cb);
         },
 
         onQRCode(cb: (qrcode?: string) => void): Unsubscribe {
+            warnDeprecated("Device.onQRCode", 'use `device.on("qrCodeChanged", cb)` instead.');
             return conn.on("qrCodeChanged", cb);
         },
 
         onContact(cb: (contact?: Contact) => void): Unsubscribe {
+            warnDeprecated("Device.onContact", 'use `device.on("contactChanged", cb)` instead.');
             return conn.on("contactChanged", cb);
         },
 

--- a/src/modules/media/MediaManager.ts
+++ b/src/modules/media/MediaManager.ts
@@ -28,23 +28,30 @@ export class MediaManager extends EventEmitter<MediaManagerEvents> {
     private attachedElements: Set<HTMLAudioElement> = new Set();
     private activeSpeakerId?: string;
     private permissionGranted = false;
-    private readonly _workletReady: Promise<void>;
+    // Lazily memoised on first `waitReady()` / `startMedia()` so a MediaManager
+    // that is constructed-then-never-used does not fetch the libsamplerate
+    // worklet over the network nor pay the addModule parse cost.
+    private _workletReady: Promise<void> | null = null;
 
     constructor() {
         super();
         this.audioContext = new AudioContext({ latencyHint: 0 });
-
-        this._workletReady = Promise.all([
-            this.audioContext.audioWorklet.addModule(LIB_SAMPLE_RATE_URL),
-            this.audioContext.audioWorklet.addModule(micWorkletUrl),
-            this.audioContext.audioWorklet.addModule(outWorkletUrl),
-        ]).then(() => this.audioContext.suspend());
 
         this.enumerateDevices();
         navigator.mediaDevices.addEventListener("devicechange", this.handleDeviceChange);
     }
 
     waitReady(): Promise<void> {
+        return this.loadWorklets();
+    }
+
+    private loadWorklets(): Promise<void> {
+        if (this._workletReady) return this._workletReady;
+        this._workletReady = Promise.all([
+            this.audioContext.audioWorklet.addModule(LIB_SAMPLE_RATE_URL),
+            this.audioContext.audioWorklet.addModule(micWorkletUrl),
+            this.audioContext.audioWorklet.addModule(outWorkletUrl),
+        ]).then(() => this.audioContext.suspend());
         return this._workletReady;
     }
 
@@ -65,7 +72,7 @@ export class MediaManager extends EventEmitter<MediaManagerEvents> {
     async startMedia(): Promise<MediaStream> {
         if (this.stream) return this.stream;
 
-        await this._workletReady;
+        await this.loadWorklets();
 
         const mic = this.activeMic ?? this.devices.find((d) => d.kind === "audioinput");
         const pinned = this.permissionGranted ? mic?.deviceId : undefined;

--- a/src/modules/media/MediaManager.ts
+++ b/src/modules/media/MediaManager.ts
@@ -1,4 +1,9 @@
 import { EventEmitter } from "@/modules/shared/EventEmitter";
+// Vendored at build time via vite-plugin-worklet: the upstream
+// `libsamplerate.worklet.js` (WASM inlined) is built to a Blob URL inside the
+// dist bundle. Replaces the previous jsdelivr CDN URL so the library no longer
+// depends on a network fetch nor on the CDN being up at consumer page-load.
+import libSampleRateWorkletUrl from "@alexanderolsen/libsamplerate-js/dist/libsamplerate.worklet.js?worklet";
 import micWorkletUrl from "../worklets/AudioWorkletMic.ts?worklet";
 import outWorkletUrl from "../worklets/AudioWorkletOut.ts?worklet";
 
@@ -48,7 +53,7 @@ export class MediaManager extends EventEmitter<MediaManagerEvents> {
     private loadWorklets(): Promise<void> {
         if (this._workletReady) return this._workletReady;
         this._workletReady = Promise.all([
-            this.audioContext.audioWorklet.addModule(LIB_SAMPLE_RATE_URL),
+            this.audioContext.audioWorklet.addModule(libSampleRateWorkletUrl),
             this.audioContext.audioWorklet.addModule(micWorkletUrl),
             this.audioContext.audioWorklet.addModule(outWorkletUrl),
         ]).then(() => this.audioContext.suspend());
@@ -299,9 +304,6 @@ export class MediaManager extends EventEmitter<MediaManagerEvents> {
         }
     }
 }
-
-export const LIB_SAMPLE_RATE_URL =
-    "https://cdn.jsdelivr.net/npm/@alexanderolsen/libsamplerate-js@2.1.2/dist/libsamplerate.worklet.js";
 
 function buildAudioConstraints(deviceId?: string): MediaStreamConstraints {
     return {

--- a/src/modules/shared/deprecation.ts
+++ b/src/modules/shared/deprecation.ts
@@ -1,0 +1,19 @@
+const warned = new Set<string>();
+
+/**
+ * Emit a `console.warn` exactly once per `key` for a deprecated API surface.
+ *
+ * Sprint D leaves the old single-listener `.onX()` methods in place but warns
+ * consumers to migrate to `.on("event", cb)`. The methods will be removed in
+ * the next major. `reset()` exists for tests that need to re-trigger the warn.
+ */
+export function warnDeprecated(key: string, message: string): void {
+    if (warned.has(key)) return;
+    warned.add(key);
+    console.warn(`[wavoip] DEPRECATED ${key}: ${message}`);
+}
+
+/** Clear the once-emitted set. Test-only. */
+export function _resetDeprecationWarnings(): void {
+    warned.clear();
+}

--- a/src/test/media/MediaManager.lazy-worklets.spec.ts
+++ b/src/test/media/MediaManager.lazy-worklets.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Worklet `?worklet` imports evaluate the AudioWorkletProcessor module body at
+// import time, which throws under happy-dom. Mock them to plain URL strings.
+vi.mock("../../modules/worklets/AudioWorkletMic.ts?worklet", () => ({ default: "mic-worklet.js" }));
+vi.mock("../../modules/worklets/AudioWorkletOut.ts?worklet", () => ({ default: "out-worklet.js" }));
+
+// AudioContext + addModule are stubbed at the global level so MediaManager's
+// constructor doesn't hit the real Web Audio API under happy-dom.
+
+const addModule = vi.fn().mockResolvedValue(undefined);
+const suspend = vi.fn().mockResolvedValue(undefined);
+const resume = vi.fn().mockResolvedValue(undefined);
+const close = vi.fn().mockResolvedValue(undefined);
+
+class FakeAudioContext {
+    state: "suspended" | "running" = "suspended";
+    audioWorklet = { addModule };
+    destination = {} as AudioNode;
+    suspend = suspend;
+    resume = resume;
+    close = close;
+    createMediaStreamSource = vi.fn();
+    createAnalyser = vi.fn();
+}
+
+beforeEach(() => {
+    addModule.mockClear();
+    suspend.mockClear();
+    resume.mockClear();
+    close.mockClear();
+    vi.stubGlobal("AudioContext", FakeAudioContext);
+    Object.defineProperty(navigator, "mediaDevices", {
+        configurable: true,
+        value: {
+            enumerateDevices: vi.fn().mockResolvedValue([]),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            getUserMedia: vi.fn(),
+        },
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("MediaManager — lazy worklet bootstrap (D2)", () => {
+    it("does not call audioWorklet.addModule in the constructor", async () => {
+        const { MediaManager } = await import("@/modules/media/MediaManager");
+        new MediaManager();
+        expect(addModule).not.toHaveBeenCalled();
+    });
+
+    it("loads worklets on first waitReady()", async () => {
+        const { MediaManager } = await import("@/modules/media/MediaManager");
+        const mm = new MediaManager();
+
+        await mm.waitReady();
+
+        // libsamplerate + mic + out
+        expect(addModule).toHaveBeenCalledTimes(3);
+        expect(suspend).toHaveBeenCalledTimes(1);
+    });
+
+    it("memoises the worklet load (second waitReady reuses the same promise)", async () => {
+        const { MediaManager } = await import("@/modules/media/MediaManager");
+        const mm = new MediaManager();
+
+        await mm.waitReady();
+        await mm.waitReady();
+        await mm.waitReady();
+
+        expect(addModule).toHaveBeenCalledTimes(3);
+    });
+});

--- a/src/test/shared/deprecation.test.ts
+++ b/src/test/shared/deprecation.test.ts
@@ -1,0 +1,48 @@
+import { _resetDeprecationWarnings, warnDeprecated } from "@/modules/shared/deprecation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("warnDeprecated", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        _resetDeprecationWarnings();
+        warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it("emits a console.warn including the key and message", () => {
+        warnDeprecated("Foo.bar", "use baz instead.");
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain("Foo.bar");
+        expect(warnSpy.mock.calls[0][0]).toContain("use baz instead.");
+    });
+
+    it("only warns once per key", () => {
+        warnDeprecated("Foo.bar", "use baz.");
+        warnDeprecated("Foo.bar", "use baz.");
+        warnDeprecated("Foo.bar", "use baz.");
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns once per distinct key", () => {
+        warnDeprecated("Foo.bar", "use baz.");
+        warnDeprecated("Foo.qux", "use baz.");
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("_resetDeprecationWarnings clears the once-emitted set", () => {
+        warnDeprecated("Foo.bar", "use baz.");
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+
+        _resetDeprecationWarnings();
+        warnDeprecated("Foo.bar", "use baz.");
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+});

--- a/vite-plugin-worklet.ts
+++ b/vite-plugin-worklet.ts
@@ -7,11 +7,23 @@ export function workletPlugin(): Plugin {
     return {
         name: "vite-plugin-worklet",
         enforce: "pre",
-        resolveId(id, importer) {
+        async resolveId(id, importer) {
             if (!id.includes("?worklet")) return;
             const cleanId = id.replace("?worklet", "");
-            const resolved = importer ? path.resolve(path.dirname(importer), cleanId) : path.resolve(cleanId);
-            return `\0worklet:${resolved}`;
+
+            // Bare node-module specifiers (e.g. "@scope/pkg/dist/foo.js?worklet")
+            // delegate to the bundler's resolver so we follow exports + node_modules.
+            // Local paths take the cheap path.resolve route to preserve the existing
+            // relative-import behaviour for `src/modules/worklets/*.ts?worklet`.
+            const isRelative = cleanId.startsWith("./") || cleanId.startsWith("../") || path.isAbsolute(cleanId);
+            if (isRelative) {
+                const resolved = importer ? path.resolve(path.dirname(importer), cleanId) : path.resolve(cleanId);
+                return `\0worklet:${resolved}`;
+            }
+
+            const resolved = await this.resolve(cleanId, importer, { skipSelf: true });
+            if (!resolved) return;
+            return `\0worklet:${resolved.id}`;
         },
         async load(id) {
             if (!id.startsWith("\0worklet:")) return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
                 globals: {
                     "socket.io-client": "io",
                     axios: "axios",
-                    "@alexanderolsen/libsamplerate-js": "libsamplerate",
                     a18n: "a18n",
                 },
             },


### PR DESCRIPTION
## Summary

Sprint D of the call/transport refactor. Stacked on PR #27. Three independent slices:

### D1 — `feat(shared)`: warn-once deprecation helper, wire all `onX` methods
- New `src/modules/shared/deprecation.ts` exports `warnDeprecated(key, message)` that emits a single `console.warn` per `key` and exposes a test-only `_resetDeprecationWarnings()` helper.
- Wired into every consumer-facing `onX` method on `Device`, `Offer`, `CallOutgoing`, `CallActive` (and the underlying `DeviceConnection`/`DeviceProxy` surfaces).
- Each warning points the consumer at the typed `.on("eventName", cb)` replacement and fires exactly once per process per method.
- Removal scheduled for next major. Aligns the consumer-facing surface with the typed event bus from Sprints A–C.
- 4 new unit tests for the helper itself (key/message echo, idempotency, distinct-key isolation, reset for test reuse).

### D2 — `perf(media)`: defer `AudioWorklet` bootstrap until first `waitReady` / `startMedia`
- `MediaManager` constructor no longer calls `audioWorklet.addModule()`. Worklets are loaded on the first `waitReady()` or `startMedia()`, then memoised via a single promise.
- Removes parse + (previously) network cost from the page-load critical path when a `Device` is constructed but never used (e.g. headless dashboards rendering device chips without an active call).
- AudioContext creation stays in the constructor — other transports take `mediaManager.audioContext` directly.
- 3 new tests in `MediaManager.lazy-worklets.spec.ts` cover: constructor is silent, first `waitReady()` triggers exactly 3 `addModule()` calls + one `suspend()`, and repeat `waitReady()` calls are memoised.

### D3 — `feat(media)`: vendor libsamplerate worklet inline, drop CDN dep
- Replaces the `cdn.jsdelivr.net/.../libsamplerate.worklet.js` URL with a build-time `?worklet` import of `@alexanderolsen/libsamplerate-js/dist/libsamplerate.worklet.js`.
- Extended `vite-plugin-worklet.ts` to follow node-module specifiers via `this.resolve()` (the local-path branch is unchanged).
- The worklet (~2 MB, WASM inlined) is bundled into the dist as a Blob URL string. No runtime network fetch, no CDN-outage failure mode, no version drift.
- Moved `@alexanderolsen/libsamplerate-js` to `devDependencies` — it's a build-only dep; the consumer install no longer pulls the 4 MB package.
- Dropped the unused `libsamplerate` UMD global from `vite.config.ts`.
- Bundle size: dist `index.es.js` grows from ~52 kB → ~2.07 MB (gzip 13 kB → 1.47 MB). Acceptable for a self-contained audio library; offsets the per-page-load CDN fetch consumers were paying anyway.

## Stack

- PR #25 `refactor/sprint-a` → `main` — 5 P0 bug fixes
- PR #26 `refactor/sprint-b` → `refactor/sprint-a` — `forwardEvents` + table-driven state machine + slim proxies
- PR #27 `refactor/sprint-c` → `refactor/sprint-b` — `CallRouter` + `kind`-discriminated `ITransport`
- **PR #28 this** `refactor/sprint-d` → `refactor/sprint-c` — deprecation warnings + lazy worklets + vendored libsamplerate

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 205 / 205 (was 198 / 198 on sprint-c; +7 new tests across D1/D2)
- [x] `pnpm build` — clean
- [ ] Manual smoke (consumer): instantiate a `Device`, do not start a call → no worklet network requests in DevTools network tab
- [ ] Manual smoke (consumer): call any deprecated `device.onStatus(...)` → exactly one `[wavoip] DEPRECATED Device.onStatus: ...` warning
- [ ] Manual smoke (consumer): full unofficial call round-trip — verifies the inlined libsamplerate worklet loads + resamples correctly under the lazy bootstrap