### PR TITLE
feat(call): type CallActive error as CallFailReason union

### DIFF
--- a/docs/calls/active.md
+++ b/docs/calls/active.md
@@ -87,7 +87,7 @@ Assine com `call.on(evento, callback)`. Retorna uma função `Unsubscribe`.
 | ~~`serverStats`~~ **(deprecated)** | `ServerCallStats`   | `call:stats` bruto enviado pelo servidor (RTT servidor↔cliente e servidor↔WhatsApp). **Use [`getStats()`](#getstats) no lugar** — os mesmos campos já estão mesclados ali para chamadas `unofficial`. Emite um aviso `console.warn` único na primeira assinatura. |
 | `iceDiagnostics`    | `IceDiagnostics`    | Diagnóstico da coleta ICE (duração, candidatos por tipo, STUN/TURN alcançados, par selecionado). Replay em listeners tardios. |
 | `connectivityIssue` | `ConnectivityIssue` | Problema de conectividade detectado (`STUN_UNREACHABLE`, `ICE_GATHERING_TIMEOUT`, `ICE_CONNECTION_FAILED`, `NO_HOST_CANDIDATES`, `SYMMETRIC_NAT_SUSPECTED`). Todos os problemas observados são re-emitidos para listeners tardios. |
-| `error`             | `string`            | Ocorreu um erro no nível de transporte.                                                                                |
+| `error`             | `CallFailReason`    | Servidor sinalizou falha da chamada. Veja [`CallFailReason`](../types.md#callfailreason) para a lista de motivos.      |
 | `status`            | `CallStatus`        | Status da chamada mudou.                                                                                               |
 
 ```typescript

--- a/docs/types.md
+++ b/docs/types.md
@@ -282,14 +282,14 @@ type CallFailReason =
 
 | Motivo                | Significado                                                                                            |
 | --------------------- | ------------------------------------------------------------------------------------------------------ |
-| `AUDIO_TIMEOUT`       | **Obsoleto.** Substituído por `PEER_RX_TIMEOUT`. Mantido para retrocompatibilidade com servidores antigos. |
-| `CORRUPTED_KEYS`      | Falha de integração ao decodificar o ACK de oferta.                                                    |
-| `CONNECTION_TIMEOUT`  | Timeout de ping entre cliente e servidor.                                                              |
-| `PEER_TX_TIMEOUT`     | Servidor parou de receber áudio do peer (silêncio TX no lado remoto).                                  |
-| `PEER_RX_TIMEOUT`     | Servidor parou de receber áudio do usuário (silêncio RX no lado local). Substitui `AUDIO_TIMEOUT`.     |
-| `ACCOUNT_RESTRICTED`  | Conta bloqueada pelo WhatsApp (ack-error 463).                                                         |
-| `NO_CALL_PERMISSION`  | Integração não tem permissão para iniciar a chamada.                                                   |
-| `INTERNAL_ERROR`      | Erro interno genérico do servidor.                                                                     |
+| `AUDIO_TIMEOUT`       | **Obsoleto.** Substituído por `PEER_RX_TIMEOUT`. Mantido para retrocompatibilidade.                    |
+| `CORRUPTED_KEYS`      | Não foi possível estabelecer a chamada com segurança.                                                  |
+| `CONNECTION_TIMEOUT`  | A chamada perdeu contato com o servidor.                                                               |
+| `PEER_TX_TIMEOUT`     | O contato parou de enviar áudio.                                                                       |
+| `PEER_RX_TIMEOUT`     | O usuário parou de enviar áudio. Substitui `AUDIO_TIMEOUT`.                                            |
+| `ACCOUNT_RESTRICTED`  | A conta do WhatsApp está restrita e não pode realizar chamadas.                                        |
+| `NO_CALL_PERMISSION`  | A conta não tem permissão para realizar chamadas.                                                      |
+| `INTERNAL_ERROR`      | Algo deu errado do lado do servidor.                                                                   |
 
 ---
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -237,7 +237,7 @@ type CallOutgoingEvents = {
 
 ```typescript
 type CallActiveEvents = {
-    error:             [err: string]
+    error:             [err: CallFailReason]
     peerMute:          []
     peerUnmute:        []
     ended:             []
@@ -262,6 +262,34 @@ type DeviceEvents = {
     restrictedChanged: [restricted: boolean]
 }
 ```
+
+### `CallFailReason`
+
+Motivo de falha emitido no evento `error` de [`CallActive`](calls/active.md). É uma união aberta: os literais conhecidos abaixo dão autocomplete, mas qualquer string vinda do servidor é aceita — assim novos motivos podem surgir sem quebrar consumidores tipados.
+
+```typescript
+type CallFailReason =
+    | "AUDIO_TIMEOUT"        // @deprecated — use "PEER_RX_TIMEOUT"
+    | "CORRUPTED_KEYS"
+    | "CONNECTION_TIMEOUT"
+    | "PEER_TX_TIMEOUT"
+    | "PEER_RX_TIMEOUT"
+    | "ACCOUNT_RESTRICTED"
+    | "NO_CALL_PERMISSION"
+    | "INTERNAL_ERROR"
+    | (string & {})
+```
+
+| Motivo                | Significado                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------ |
+| `AUDIO_TIMEOUT`       | **Obsoleto.** Substituído por `PEER_RX_TIMEOUT`. Mantido para retrocompatibilidade com servidores antigos. |
+| `CORRUPTED_KEYS`      | Falha de integração ao decodificar o ACK de oferta.                                                    |
+| `CONNECTION_TIMEOUT`  | Timeout de ping entre cliente e servidor.                                                              |
+| `PEER_TX_TIMEOUT`     | Servidor parou de receber áudio do peer (silêncio TX no lado remoto).                                  |
+| `PEER_RX_TIMEOUT`     | Servidor parou de receber áudio do usuário (silêncio RX no lado local). Substitui `AUDIO_TIMEOUT`.     |
+| `ACCOUNT_RESTRICTED`  | Conta bloqueada pelo WhatsApp (ack-error 463).                                                         |
+| `NO_CALL_PERMISSION`  | Integração não tem permissão para iniciar a chamada.                                                   |
+| `INTERNAL_ERROR`      | Erro interno genérico do servidor.                                                                     |
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export type { CallDirection, CallStatus, CallType } from "@/modules/device/Call";
+export type { CallFailReason } from "@/modules/device/CallFailReason";
 export type { CallStats, ServerCallStats } from "@/modules/call/Stats";
 export type { CallActive, CallActiveEvents } from "@/modules/call/CallActive";
 export type { CallOutgoing, CallOutgoingEvents } from "@/modules/call/CallOutgoing";

--- a/src/modules/call/CallActive.ts
+++ b/src/modules/call/CallActive.ts
@@ -1,6 +1,7 @@
 import type { CallPeer } from "@/modules/call/Peer";
 import type { CallStats, ServerCallStats } from "@/modules/call/Stats";
 import type { Call, CallDirection, CallStatus, CallType } from "@/modules/device/Call";
+import type { CallFailReason } from "@/modules/device/CallFailReason";
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import type { ITransport, TransportStatus } from "@/modules/media/ITransport";
 import type { MediaManager } from "@/modules/media/MediaManager";
@@ -9,7 +10,7 @@ import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 import { forwardEvents } from "@/modules/shared/forwardEvents";
 
 export type CallActiveEvents = {
-    error: [err: string];
+    error: [err: CallFailReason];
     peerMute: [];
     peerUnmute: [];
     ended: [];
@@ -51,7 +52,7 @@ export interface CallActive {
     getStats(): Promise<CallStats>;
     on<T extends keyof CallActiveEvents>(event: T, callback: (...args: CallActiveEvents[T]) => void): Unsubscribe;
     /** @deprecated Use `on("error", callback)` instead. */
-    onError(callback: (err: string) => void): void;
+    onError(callback: (err: CallFailReason) => void): void;
     /** @deprecated Use `on("peerMute", callback)` instead. */
     onPeerMute(callback: () => void): void;
     /** @deprecated Use `on("peerUnmute", callback)` instead. */
@@ -173,7 +174,7 @@ export function CallActiveProxy(
         },
 
         /** @deprecated Use `on("error", callback)` instead. */
-        onError(callback: (err: string) => void): void {
+        onError(callback: (err: CallFailReason) => void): void {
             warnDeprecated("CallActive.onError", 'use `active.on("error", cb)` instead.');
             onErrorUnsub?.();
             onErrorUnsub = emitter.on("error", callback);

--- a/src/modules/device/Call.ts
+++ b/src/modules/device/Call.ts
@@ -1,4 +1,5 @@
 import { type CallStats, type ServerCallStats, makeEmptyCallStats } from "@/modules/call/Stats";
+import type { CallFailReason } from "@/modules/device/CallFailReason";
 import type { MediaPlan } from "@/modules/device/WebSocket";
 import type { ConnectivityIssue, IceDiagnostics } from "@/modules/media/ICEDiagnostics";
 import { type ITransport, type TransportStatus, isRTCTransport } from "@/modules/media/ITransport";
@@ -13,7 +14,7 @@ export type CallEvents = {
     answered: [mediaPlan: MediaPlan];
     rejected: [];
     unanswered: [];
-    failed: [error: string];
+    failed: [error: CallFailReason];
     connectionStatus: [status: TransportStatus];
     peerMuted: [muted: boolean];
     stats: [stats: CallStats];

--- a/src/modules/device/CallFailReason.ts
+++ b/src/modules/device/CallFailReason.ts
@@ -17,28 +17,21 @@
 export type CallFailReason =
     /**
      * @deprecated Use {@link CallFailReason} `"PEER_RX_TIMEOUT"` instead.
-     * Kept for backward compatibility while older server builds still emit
-     * the legacy `client:audio-timeout` cause.
+     * Kept for backward compatibility.
      */
     | "AUDIO_TIMEOUT"
-    /** Integration failure decoding the offer ACK. */
+    /** The call could not be established securely. */
     | "CORRUPTED_KEYS"
-    /** Ping timeout between client and server. */
+    /** The call lost contact with the server. */
     | "CONNECTION_TIMEOUT"
-    /**
-     * Server stopped receiving audio from the peer (peer-side TX silence).
-     * Typically the WhatsApp leg dropped or the peer muted unexpectedly.
-     */
+    /** The contact stopped sending audio. */
     | "PEER_TX_TIMEOUT"
-    /**
-     * Server stopped receiving audio from the user (user-side RX silence).
-     * Supersedes the legacy `"AUDIO_TIMEOUT"` reason.
-     */
+    /** The user stopped sending audio. Supersedes `"AUDIO_TIMEOUT"`. */
     | "PEER_RX_TIMEOUT"
-    /** WhatsApp returned ack-error 463 — account is restricted. */
+    /** The WhatsApp account is restricted and cannot place calls. */
     | "ACCOUNT_RESTRICTED"
-    /** Integration forbade the call (missing permission). */
+    /** The account is not allowed to place calls. */
     | "NO_CALL_PERMISSION"
-    /** Catch-all server-side internal error. */
+    /** Something went wrong on the server side. */
     | "INTERNAL_ERROR"
     | (string & {});

--- a/src/modules/device/CallFailReason.ts
+++ b/src/modules/device/CallFailReason.ts
@@ -1,0 +1,44 @@
+/**
+ * Reasons emitted by the server on the `call:failed` socket event and surfaced
+ * to consumers via the {@link CallActive} `"error"` event.
+ *
+ * The union is loose (`| (string & {})`): typing as a literal union gives
+ * autocomplete for known reasons in editors, while still accepting any future
+ * server-side reason without forcing a library bump.
+ *
+ * Source of truth: `whatsapp_instance` server's `Helper.mapError` — keep this
+ * union in sync with the strings that function returns.
+ *
+ * @example
+ *   active.on("error", (reason) => {
+ *       if (reason === "PEER_TX_TIMEOUT") notifyPeerSilence();
+ *   });
+ */
+export type CallFailReason =
+    /**
+     * @deprecated Use {@link CallFailReason} `"PEER_RX_TIMEOUT"` instead.
+     * Kept for backward compatibility while older server builds still emit
+     * the legacy `client:audio-timeout` cause.
+     */
+    | "AUDIO_TIMEOUT"
+    /** Integration failure decoding the offer ACK. */
+    | "CORRUPTED_KEYS"
+    /** Ping timeout between client and server. */
+    | "CONNECTION_TIMEOUT"
+    /**
+     * Server stopped receiving audio from the peer (peer-side TX silence).
+     * Typically the WhatsApp leg dropped or the peer muted unexpectedly.
+     */
+    | "PEER_TX_TIMEOUT"
+    /**
+     * Server stopped receiving audio from the user (user-side RX silence).
+     * Supersedes the legacy `"AUDIO_TIMEOUT"` reason.
+     */
+    | "PEER_RX_TIMEOUT"
+    /** WhatsApp returned ack-error 463 — account is restricted. */
+    | "ACCOUNT_RESTRICTED"
+    /** Integration forbade the call (missing permission). */
+    | "NO_CALL_PERMISSION"
+    /** Catch-all server-side internal error. */
+    | "INTERNAL_ERROR"
+    | (string & {});

--- a/src/modules/device/WebSocket.ts
+++ b/src/modules/device/WebSocket.ts
@@ -1,6 +1,7 @@
 import type { CallPeer } from "@/modules/call/Peer";
 import type { ServerCallStats } from "@/modules/call/Stats";
 import type { CallType } from "@/modules/device/Call";
+import type { CallFailReason } from "@/modules/device/CallFailReason";
 import type { Contact, DeviceStatus } from "@/modules/device/Device";
 import { io } from "socket.io-client";
 import type { Socket } from "socket.io-client";
@@ -62,7 +63,7 @@ export type ServerEvents = {
     "call:rejected": (callId: string) => void;
     "call:ended": (callId: string) => void;
     "call:unanswered": (callId: string) => void;
-    "call:failed": (callId: string, error: string) => void;
+    "call:failed": (callId: string, error: CallFailReason) => void;
     "call:stats": (callId: string, stats: ServerCallStats) => void;
     "call:peer:muted": (callId: string, muted: boolean) => void;
 };

--- a/src/test/device/CallRouter.test.ts
+++ b/src/test/device/CallRouter.test.ts
@@ -213,6 +213,26 @@ describe("CallRouter", () => {
             expect(cb).toHaveBeenCalledWith("boom");
             expect(router.has(call.id)).toBe(false);
         });
+
+        it.each([
+            "AUDIO_TIMEOUT",
+            "PEER_TX_TIMEOUT",
+            "PEER_RX_TIMEOUT",
+            "CONNECTION_TIMEOUT",
+            "INTERNAL_ERROR",
+        ])("call:failed forwards canonical reason %s", (reason) => {
+            const socket = makeMockSocket();
+            const router = new CallRouter(socket as unknown as DeviceSocket);
+            router.start();
+            const call = makeCall();
+            router.register(call);
+            const cb = vi.fn();
+            call.on("failed", cb);
+
+            emitSocket(socket, "call:failed", call.id, reason);
+
+            expect(cb).toHaveBeenCalledWith(reason);
+        });
     });
 
     describe("register / unregister", () => {


### PR DESCRIPTION
## Summary
- Add `CallFailReason` loose union covering 8 server-side reasons (`PEER_TX_TIMEOUT`, `PEER_RX_TIMEOUT`, `AUDIO_TIMEOUT`, `CORRUPTED_KEYS`, `CONNECTION_TIMEOUT`, `ACCOUNT_RESTRICTED`, `NO_CALL_PERMISSION`, `INTERNAL_ERROR`) — mirrors `Helper.mapError` in `whatsapp_instance`.
- `AUDIO_TIMEOUT` kept as `@deprecated` alias of `PEER_RX_TIMEOUT` for retrocompat with older server builds.
- Type wired through `Call.failed`, `WebSocket.call:failed`, `CallActive.error`. Exported from `src/index.ts`.
- pt-BR docs updated (`docs/types.md`, `docs/calls/active.md`).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (250 passed)
- [x] `pnpm build`
- [ ] Consumer (`webphone`) compiles against new types