### PR TITLE
feat(device): expose restrictedUntil from device:init and device:restriction:changed

### DIFF
--- a/docs/device.md
+++ b/docs/device.md
@@ -13,14 +13,15 @@ Os dispositivos são retornados por `wavoip.getDevices()`, `wavoip.addDevices()`
 
 ## Propriedades
 
-| Propriedade        | Tipo                  | Descrição                                                                                  |
-| ------------------ | --------------------- | ------------------------------------------------------------------------------------------ |
-| `token`            | `string`              | Token único do dispositivo (somente leitura).                                              |
-| `status`           | `DeviceStatus`        | Estado atual de conexão/pareamento.                                                        |
-| `qrCode`           | `string \| undefined` | String do QR code quando o dispositivo está em `connecting`.                               |
-| `contact`          | `Contact \| undefined`| Número WhatsApp vinculado quando o dispositivo está `open`.                                |
-| `restricted`       | `boolean`             | `true` quando a conta WhatsApp está restrita e impedida de iniciar chamadas.               |
-| `restrictedUntil`  | `Date \| null`        | Data em que a restrição expira. `null` quando não há restrição ativa ou data informada.    |
+| Propriedade        | Tipo                   | Descrição                                                                                  |
+| ------------------ | ---------------------- | ------------------------------------------------------------------------------------------ |
+| `token`            | `string`               | Token único do dispositivo (somente leitura).                                              |
+| `status`           | `DeviceStatus`         | Estado da conta WhatsApp.                                                                  |
+| `connectionStatus` | `ConnectionStatus`     | Estado do WebSocket entre SDK e backend (`connected` / `disconnected` / `reconnecting`).   |
+| `qrCode`           | `string \| undefined`  | String do QR code quando o dispositivo está em `connecting`.                               |
+| `contact`          | `Contact \| undefined` | Número WhatsApp vinculado quando o dispositivo está `open`.                                |
+| `restricted`       | `boolean`              | `true` quando a conta WhatsApp está restrita e impedida de iniciar chamadas.               |
+| `restrictedUntil`  | `Date \| null`         | Data em que a restrição expira. `null` quando não há restrição ativa ou data informada.    |
 
 ---
 
@@ -28,7 +29,6 @@ Os dispositivos são retornados por `wavoip.getDevices()`, `wavoip.addDevices()`
 
 | Status                       | Significado                                                                  |
 | ---------------------------- | ---------------------------------------------------------------------------- |
-| `disconnected`               | WebSocket não está conectado. Reconexão automática em andamento.             |
 | `close`                      | Conectado, mas sem número WhatsApp vinculado. Pode entrar em hibernação.     |
 | `connecting`                 | QR code pronto — aguardando leitura pelo WhatsApp.                           |
 | `open`                       | Vinculado e pronto para realizar/receber chamadas.                           |
@@ -74,6 +74,18 @@ Emitido quando o contato WhatsApp vinculado muda — no pareamento, logout ou re
 ```typescript
 device.on("contactChanged", (contact?: Contact) => {
     if (contact) console.log("Vinculado a:", contact.phone)
+})
+```
+
+### `connectionStatusChanged`
+
+Emitido quando o estado do WebSocket entre SDK e backend muda. Use este evento para refletir queda/restauro de conexão na UI, independentemente do `statusChanged` (que descreve o estado da conta WhatsApp).
+
+```typescript
+device.on("connectionStatusChanged", (status: ConnectionStatus) => {
+    if (status === "disconnected") showOfflineBanner()
+    if (status === "reconnecting") showReconnectingSpinner()
+    if (status === "connected") hideBanners()
 })
 ```
 

--- a/docs/device.md
+++ b/docs/device.md
@@ -13,12 +13,14 @@ Os dispositivos são retornados por `wavoip.getDevices()`, `wavoip.addDevices()`
 
 ## Propriedades
 
-| Propriedade | Tipo                  | Descrição                                                    |
-| ----------- | --------------------- | ------------------------------------------------------------ |
-| `token`     | `string`              | Token único do dispositivo (somente leitura).                |
-| `status`    | `DeviceStatus`        | Estado atual de conexão/pareamento.                          |
-| `qrCode`    | `string \| undefined` | String do QR code quando o dispositivo está em `connecting`. |
-| `contact`   | `Contact \| undefined`| Número WhatsApp vinculado quando o dispositivo está `open`.  |
+| Propriedade        | Tipo                  | Descrição                                                                                  |
+| ------------------ | --------------------- | ------------------------------------------------------------------------------------------ |
+| `token`            | `string`              | Token único do dispositivo (somente leitura).                                              |
+| `status`           | `DeviceStatus`        | Estado atual de conexão/pareamento.                                                        |
+| `qrCode`           | `string \| undefined` | String do QR code quando o dispositivo está em `connecting`.                               |
+| `contact`          | `Contact \| undefined`| Número WhatsApp vinculado quando o dispositivo está `open`.                                |
+| `restricted`       | `boolean`             | `true` quando a conta WhatsApp está restrita e impedida de iniciar chamadas.               |
+| `restrictedUntil`  | `Date \| null`        | Data em que a restrição expira. `null` quando não há restrição ativa ou data informada.    |
 
 ---
 
@@ -72,6 +74,16 @@ Emitido quando o contato WhatsApp vinculado muda — no pareamento, logout ou re
 ```typescript
 device.on("contactChanged", (contact?: Contact) => {
     if (contact) console.log("Vinculado a:", contact.phone)
+})
+```
+
+### `restrictedChanged`
+
+Emitido quando o estado de restrição da conta muda. O segundo argumento é a data em que a restrição expira, quando informada pelo servidor — pode ser `null` em instâncias mais antigas que não enviam essa data.
+
+```typescript
+device.on("restrictedChanged", (restricted: boolean, restrictedUntil: Date | null) => {
+    if (restricted && restrictedUntil) console.log("Restrito até:", restrictedUntil)
 })
 ```
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -259,7 +259,7 @@ type DeviceEvents = {
     statusChanged:     [status: DeviceStatus]
     qrCodeChanged:     [qrCode?: string]
     contactChanged:    [contact?: Contact]
-    restrictedChanged: [restricted: boolean]
+    restrictedChanged: [restricted: boolean, restrictedUntil: Date | null]
 }
 ```
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -172,7 +172,6 @@ Use `runStunProbe(servers, timeoutMs?)` para testar a alcançabilidade de servid
 ```typescript
 type DeviceStatus =
     | "UP"                        // (legado) Dispositivo em execução
-    | "disconnected"              // WebSocket não conectado
     | "close"                     // Conectado, sem WhatsApp vinculado
     | "connecting"                // QR code pronto, aguardando leitura
     | "open"                      // Vinculado e pronto para chamadas
@@ -181,6 +180,17 @@ type DeviceStatus =
     | "BUILDING"                  // Inicializando
     | "WAITING_PAYMENT"           // Pagamento da conta necessário
     | "EXTERNAL_INTEGRATION_ERROR"// Falha na integração externa
+```
+
+### `ConnectionStatus`
+
+Estado do WebSocket entre SDK e backend. Independente do `DeviceStatus` (nível de conta).
+
+```typescript
+type ConnectionStatus =
+    | "connected"     // WebSocket aberto e recebendo eventos
+    | "disconnected"  // WebSocket fechado; sem tentativa de reconexão em andamento
+    | "reconnecting"  // Tentando reabrir o WebSocket após queda
 ```
 
 ### `Contact`
@@ -256,10 +266,11 @@ type CallActiveEvents = {
 
 ```typescript
 type DeviceEvents = {
-    statusChanged:     [status: DeviceStatus]
-    qrCodeChanged:     [qrCode?: string]
-    contactChanged:    [contact?: Contact]
-    restrictedChanged: [restricted: boolean, restrictedUntil: Date | null]
+    statusChanged:           [status: DeviceStatus]
+    connectionStatusChanged: [status: ConnectionStatus]
+    qrCodeChanged:           [qrCode?: string]
+    contactChanged:          [contact?: Contact]
+    restrictedChanged:       [restricted: boolean, restrictedUntil: Date | null]
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export type { CallOutgoing, CallOutgoingEvents } from "@/modules/call/CallOutgoi
 export type { Offer, OfferEvents } from "@/modules/call/Offer";
 export type { CallPeer } from "@/modules/call/Peer";
 
-export type { DeviceStatus, Contact } from "@/modules/device/Device";
+export type { ConnectionStatus, DeviceStatus, Contact } from "@/modules/device/Device";
 export type { Device, DeviceEvents } from "@/modules/device/DeviceConnection";
 
 export type { TransportStatus } from "@/modules/media/ITransport";

--- a/src/modules/device/Device.ts
+++ b/src/modules/device/Device.ts
@@ -22,6 +22,7 @@ export class DeviceModel {
     public status: DeviceStatus = "disconnected";
     public callType: CallType = "OFFICIAL";
     public restricted = false;
+    public restrictedUntil: Date | null = null;
 
     constructor(public readonly token: string) {}
 

--- a/src/modules/device/Device.ts
+++ b/src/modules/device/Device.ts
@@ -1,9 +1,12 @@
 import { Call, type CallType, type Peer } from "@/modules/device/Call";
 import { t } from "@/modules/shared/i18n";
 
+/**
+ * Account-level device status. WebSocket transport state is tracked separately
+ * via `ConnectionStatus` and `connectionStatusChanged`.
+ */
 export type DeviceStatus =
     | "UP"
-    | "disconnected"
     | "close"
     | "connecting"
     | "open"
@@ -14,12 +17,16 @@ export type DeviceStatus =
     | "WAITING_PAYMENT"
     | "EXTERNAL_INTEGRATION_ERROR";
 
+/** WebSocket transport state, independent of the account-level `DeviceStatus`. */
+export type ConnectionStatus = "connected" | "disconnected" | "reconnecting";
+
 export type Contact = { phone: string };
 
 export class DeviceModel {
     public qrCode?: string = undefined;
     public contact?: Contact;
-    public status: DeviceStatus = "disconnected";
+    public status: DeviceStatus = "BUILDING";
+    public connectionStatus: ConnectionStatus = "disconnected";
     public callType: CallType = "OFFICIAL";
     public restricted = false;
     public restrictedUntil: Date | null = null;

--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -20,7 +20,7 @@ export type DeviceEvents = {
     statusChanged: [status: DeviceStatus];
     qrCodeChanged: [qrCode?: string];
     contactChanged: [contact?: Contact];
-    restrictedChanged: [restricted: boolean];
+    restrictedChanged: [restricted: boolean, restrictedUntil: Date | null];
 };
 
 type Events = DeviceEvents & {
@@ -33,6 +33,7 @@ export interface Device {
     contact?: Contact;
     status: DeviceStatus;
     restricted: boolean;
+    restrictedUntil: Date | null;
     on<T extends keyof DeviceEvents>(event: T, callback: (...args: DeviceEvents[T]) => void): Unsubscribe;
     /** @deprecated Use `on("statusChanged", callback)` instead. */
     onStatus(cb: (status: DeviceStatus) => void): Unsubscribe;
@@ -73,20 +74,22 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
         this.router.start();
         this.wss.on("disconnect", this.onDisconnect.bind(this));
 
-        this.wss.on("device:init", (status, callType, contact, qrCode, restricted) => {
+        this.wss.on("device:init", (status, callType, contact, qrCode, restricted, restrictedUntil) => {
             this.device.status = status;
             this.device.callType = callType;
             this.device.contact = contact ?? undefined;
             this.device.qrCode = qrCode ?? undefined;
             this.device.restricted = restricted;
+            this.device.restrictedUntil = restrictedUntil ? new Date(restrictedUntil) : null;
             this.emit("statusChanged", this.device.status);
             this.emit("contactChanged", this.device.contact);
             this.emit("qrCodeChanged", this.device.qrCode);
-            this.emit("restrictedChanged", this.device.restricted);
+            this.emit("restrictedChanged", this.device.restricted, this.device.restrictedUntil);
         });
-        this.wss.on("device:restriction:changed", (restricted) => {
+        this.wss.on("device:restriction:changed", (restricted, restrictedUntil) => {
             this.device.restricted = restricted;
-            this.emit("restrictedChanged", this.device.restricted);
+            this.device.restrictedUntil = restrictedUntil ? new Date(restrictedUntil) : null;
+            this.emit("restrictedChanged", this.device.restricted, this.device.restrictedUntil);
         });
         this.wss.on("device:building", () => {
             this.device.status = "BUILDING";
@@ -105,6 +108,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
             this.device.contact = undefined;
             this.device.qrCode = qrcode ?? undefined;
             this.device.restricted = false;
+            this.device.restrictedUntil = null;
             this.emit("statusChanged", this.device.status);
             this.emit("contactChanged", this.device.contact);
             this.emit("qrCodeChanged", this.device.qrCode);
@@ -114,6 +118,7 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
             this.device.contact = undefined;
             this.device.qrCode = undefined;
             this.device.restricted = false;
+            this.device.restrictedUntil = null;
             this.emit("statusChanged", this.device.status);
             this.emit("contactChanged", this.device.contact);
             this.emit("qrCodeChanged", this.device.qrCode);
@@ -150,6 +155,10 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     get restricted(): boolean {
         return this.device.restricted;
+    }
+
+    get restrictedUntil(): Date | null {
+        return this.device.restrictedUntil;
     }
 
     get socket(): DeviceSocket {

--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -4,7 +4,7 @@ import { type Offer, OfferProxy } from "@/modules/call/Offer";
 import { Call } from "@/modules/device/Call";
 import { CallRouter } from "@/modules/device/CallRouter";
 import { DeviceModel } from "@/modules/device/Device";
-import type { Contact, DeviceStatus } from "@/modules/device/Device";
+import type { ConnectionStatus, Contact, DeviceStatus } from "@/modules/device/Device";
 import { type DeviceSocket, DeviceWebSocketFactory } from "@/modules/device/WebSocket";
 import type { MediaPlan, MediaPlanRelay, MediaPlanWebRTC } from "@/modules/device/WebSocket";
 import type { TransportOptions } from "@/modules/media/ITransport";
@@ -18,6 +18,7 @@ import axios from "axios";
 
 export type DeviceEvents = {
     statusChanged: [status: DeviceStatus];
+    connectionStatusChanged: [status: ConnectionStatus];
     qrCodeChanged: [qrCode?: string];
     contactChanged: [contact?: Contact];
     restrictedChanged: [restricted: boolean, restrictedUntil: Date | null];
@@ -32,6 +33,7 @@ export interface Device {
     qrCode?: string;
     contact?: Contact;
     status: DeviceStatus;
+    connectionStatus: ConnectionStatus;
     restricted: boolean;
     restrictedUntil: Date | null;
     on<T extends keyof DeviceEvents>(event: T, callback: (...args: DeviceEvents[T]) => void): Unsubscribe;
@@ -81,6 +83,10 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
             this.device.qrCode = qrCode ?? undefined;
             this.device.restricted = restricted;
             this.device.restrictedUntil = restrictedUntil ? new Date(restrictedUntil) : null;
+            if (this.device.connectionStatus !== "connected") {
+                this.device.connectionStatus = "connected";
+                this.emit("connectionStatusChanged", this.device.connectionStatus);
+            }
             this.emit("statusChanged", this.device.status);
             this.emit("contactChanged", this.device.contact);
             this.emit("qrCodeChanged", this.device.qrCode);
@@ -151,6 +157,10 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     get status(): DeviceStatus {
         return this.device.status;
+    }
+
+    get connectionStatus(): ConnectionStatus {
+        return this.device.connectionStatus;
     }
 
     get restricted(): boolean {
@@ -281,7 +291,10 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
     }
 
     private onDisconnect() {
-        this.device.status = "disconnected";
+        if (this.device.connectionStatus !== "disconnected") {
+            this.device.connectionStatus = "disconnected";
+            this.emit("connectionStatusChanged", this.device.connectionStatus);
+        }
         if (this.stopped) return;
         if (this.wss.active) return;
         this.reconnect();
@@ -290,12 +303,18 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
     private reconnect(attempt = 1) {
         if (attempt === 3 || this.wss.connected || this.stopped) return;
 
+        if (this.device.connectionStatus !== "reconnecting") {
+            this.device.connectionStatus = "reconnecting";
+            this.emit("connectionStatusChanged", this.device.connectionStatus);
+        }
+
         setTimeout(async () => {
             if (this.stopped) return;
             const infos = await this.getInfos();
             if (this.stopped) return;
             if (!infos) return this.reconnect(attempt + 1);
             this.device.status = infos.status;
+            this.emit("statusChanged", this.device.status);
             this.wss.connect();
         }, attempt * 1000);
     }

--- a/src/modules/device/DeviceProxy.ts
+++ b/src/modules/device/DeviceProxy.ts
@@ -10,6 +10,7 @@ export function DeviceProxy(conn: DeviceConnection): Device {
         qrCode: conn.qrCode,
         contact: conn.contact,
         status: conn.status,
+        connectionStatus: conn.connectionStatus,
         restricted: conn.restricted,
         restrictedUntil: conn.restrictedUntil,
 

--- a/src/modules/device/DeviceProxy.ts
+++ b/src/modules/device/DeviceProxy.ts
@@ -11,6 +11,7 @@ export function DeviceProxy(conn: DeviceConnection): Device {
         contact: conn.contact,
         status: conn.status,
         restricted: conn.restricted,
+        restrictedUntil: conn.restrictedUntil,
 
         on<T extends keyof DeviceEvents>(event: T, callback: (...args: DeviceEvents[T]) => void): Unsubscribe {
             return conn.on(event, callback);

--- a/src/modules/device/WebSocket.ts
+++ b/src/modules/device/WebSocket.ts
@@ -47,6 +47,8 @@ export type ServerEvents = {
         contact: Contact | null,
         qrCode: string | null,
         restricted: boolean,
+        // Optional: older instance versions omit this arg. Treat undefined as null.
+        restrictedUntil?: string | null,
     ) => void;
     "device:building": () => void;
     "device:open": (contact: Contact) => void;
@@ -54,7 +56,8 @@ export type ServerEvents = {
     "device:close": () => void;
     "device:restarting": () => void;
     "device:hibernating": () => void;
-    "device:restriction:changed": (restricted: boolean) => void;
+    // Optional restrictedUntil: older instance versions omit this arg. Treat undefined as null.
+    "device:restriction:changed": (restricted: boolean, restrictedUntil?: string | null) => void;
 
     "call:offer": (call: { id: string; peer: CallPeer; offer: MediaPlan }, ackOffer: () => void) => void;
     "call:ringing": (callId: string) => void;

--- a/src/test/device/DeviceConnection.test.ts
+++ b/src/test/device/DeviceConnection.test.ts
@@ -335,7 +335,30 @@ describe("DeviceConnection — calls map cleanup", () => {
             socket.receive("device:init", "UP", "UNOFFICIAL", null, null, true);
 
             expect(dc.restricted).toBe(true);
-            expect(cb).toHaveBeenCalledWith(true);
+            expect(dc.restrictedUntil).toBe(null);
+            expect(cb).toHaveBeenCalledWith(true, null);
+        });
+
+        it("device:init parses restrictedUntil ISO string into Date", () => {
+            const { dc, socket } = makeDeviceConnection();
+            const cb = vi.fn();
+            dc.on("restrictedChanged", cb);
+            const iso = "2030-01-15T12:34:56.000Z";
+
+            socket.receive("device:init", "UP", "UNOFFICIAL", null, null, true, iso);
+
+            expect(dc.restrictedUntil).toBeInstanceOf(Date);
+            expect(dc.restrictedUntil?.toISOString()).toBe(iso);
+            expect(cb).toHaveBeenCalledWith(true, expect.any(Date));
+        });
+
+        it("device:init from older instance (no restrictedUntil arg) keeps restrictedUntil null", () => {
+            const { dc, socket } = makeDeviceConnection();
+
+            socket.receive("device:init", "UP", "UNOFFICIAL", null, null, true);
+
+            expect(dc.restricted).toBe(true);
+            expect(dc.restrictedUntil).toBe(null);
         });
 
         it("device:restriction:changed updates state and fires restrictedChanged", () => {
@@ -347,11 +370,26 @@ describe("DeviceConnection — calls map cleanup", () => {
 
             socket.receive("device:restriction:changed", true);
             expect(dc.restricted).toBe(true);
-            expect(cb).toHaveBeenLastCalledWith(true);
+            expect(cb).toHaveBeenLastCalledWith(true, null);
 
             socket.receive("device:restriction:changed", false);
             expect(dc.restricted).toBe(false);
-            expect(cb).toHaveBeenLastCalledWith(false);
+            expect(cb).toHaveBeenLastCalledWith(false, null);
+        });
+
+        it("device:restriction:changed parses restrictedUntil ISO string into Date", () => {
+            const { dc, socket } = makeDeviceConnection();
+            socket.receive("device:init", "UP", "UNOFFICIAL", null, null, false);
+
+            const cb = vi.fn();
+            dc.on("restrictedChanged", cb);
+            const iso = "2030-01-15T12:34:56.000Z";
+
+            socket.receive("device:restriction:changed", true, iso);
+
+            expect(dc.restricted).toBe(true);
+            expect(dc.restrictedUntil?.toISOString()).toBe(iso);
+            expect(cb).toHaveBeenLastCalledWith(true, expect.any(Date));
         });
 
         it("startCall returns error when device is restricted", async () => {

--- a/src/test/device/DeviceConnection.test.ts
+++ b/src/test/device/DeviceConnection.test.ts
@@ -134,6 +134,55 @@ describe("DeviceConnection — manual disconnect", () => {
     });
 });
 
+describe("DeviceConnection — connectionStatusChanged on socket disconnect/reconnect", () => {
+    it("emits connectionStatusChanged('disconnected') when the socket fires 'disconnect'", () => {
+        const { dc, socket } = makeDeviceConnection();
+        socket.receive("device:init", "open", "UNOFFICIAL", { phone: "5511" }, null, false);
+        const cb = vi.fn();
+        dc.on("connectionStatusChanged", cb);
+
+        socket.receive("disconnect");
+
+        expect(cb.mock.calls[0]?.[0]).toBe("disconnected");
+    });
+
+    it("emits connectionStatusChanged('reconnecting') after starting reconnect attempts", async () => {
+        vi.useFakeTimers();
+        const { dc, socket } = makeDeviceConnection();
+        socket.receive("device:init", "open", "UNOFFICIAL", { phone: "5511" }, null, false);
+        const cb = vi.fn();
+        dc.on("connectionStatusChanged", cb);
+
+        socket.receive("disconnect");
+        await vi.advanceTimersByTimeAsync(0);
+
+        const calls = cb.mock.calls.map((c) => c[0]);
+        expect(calls).toContain("disconnected");
+        expect(calls).toContain("reconnecting");
+        vi.useRealTimers();
+    });
+
+    it("emits connectionStatusChanged('connected') on device:init", () => {
+        const { dc, socket } = makeDeviceConnection();
+        const cb = vi.fn();
+        dc.on("connectionStatusChanged", cb);
+
+        socket.receive("device:init", "UP", "UNOFFICIAL", null, null, false);
+
+        expect(cb).toHaveBeenCalledWith("connected");
+        expect(dc.connectionStatus).toBe("connected");
+    });
+
+    it("does not mutate device.status on socket disconnect", () => {
+        const { dc, socket } = makeDeviceConnection();
+        socket.receive("device:init", "open", "UNOFFICIAL", { phone: "5511" }, null, false);
+
+        socket.receive("disconnect");
+
+        expect(dc.status).toBe("open");
+    });
+});
+
 describe("DeviceConnection — calls map cleanup", () => {
     describe("official incoming call", () => {
         it("adds call to map when offer arrives", () => {


### PR DESCRIPTION
## Summary

- `DeviceModel` adds `restrictedUntil: Date | null`, parsed from the ISO string emitted by the instance.
- `device.restrictedUntil` getter exposed on the public `Device` interface.
- `restrictedChanged` event payload extended to `[restricted: boolean, restrictedUntil: Date | null]` — existing listeners reading only the boolean keep working.
- `ServerEvents` types mark the new `restrictedUntil` arg as optional on `device:init` and `device:restriction:changed`, since older instance versions omit it.

## Backward compatibility

- **Old instance + new SDK:** instance does not send the extra Socket.IO arg → SDK handler receives `undefined` → `restrictedUntil` stored as `null`. No crash, no behavior change.
- **New instance + old SDK:** old SDK handlers ignore the extra positional arg.
- **Old consumer code:** event listeners that destructure only `(restricted)` keep working — second tuple element is silently ignored.

## Docs

- `docs/device.md`: added `restricted` and `restrictedUntil` to the properties table; new `restrictedChanged` event section.
- `docs/types.md`: `DeviceEvents.restrictedChanged` updated.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 253/253 pass, new coverage for: ISO string parsed into Date on both events, no-arg (old instance) path returns null.
- [x] `pnpm build` — clean