### PR TITLE
feat(device): activeCalls + activeCallsChanged event

### DIFF
--- a/docs/device.md
+++ b/docs/device.md
@@ -22,6 +22,7 @@ Os dispositivos são retornados por `wavoip.getDevices()`, `wavoip.addDevices()`
 | `contact`          | `Contact \| undefined` | Número WhatsApp vinculado quando o dispositivo está `open`.                                |
 | `restricted`       | `boolean`              | `true` quando a conta WhatsApp está restrita e impedida de iniciar chamadas.               |
 | `restrictedUntil`  | `Date \| null`         | Data em que a restrição expira. `null` quando não há restrição ativa ou data informada.    |
+| `activeCalls`      | `number`               | Quantidade de chamadas ativas no momento (apenas `ACTIVE`; ofertas não contam).            |
 
 ---
 
@@ -98,6 +99,22 @@ device.on("restrictedChanged", (restricted: boolean, restrictedUntil: Date | nul
     if (restricted && restrictedUntil) console.log("Restrito até:", restrictedUntil)
 })
 ```
+
+### `activeCallsChanged`
+
+Emitido quando o número de chamadas ativas do dispositivo muda. Somente chamadas em `ACTIVE` (aceitas / conversando) são contadas — ofertas em `RINGING` ou `CALLING` não entram nesse contador nem consomem canais do `num_channels`.
+
+Use-o, por exemplo, para exibir `ativas / total` no card do dispositivo, ou para bloquear ações que dependem de o dispositivo estar ocioso.
+
+```typescript
+device.on("activeCallsChanged", (count: number) => {
+    console.log("Chamadas ativas:", count)
+})
+```
+
+{% hint style="info" %}
+Instâncias mais antigas do backend não enviam este evento. Nesse caso `device.activeCalls` permanece em `0` e nenhum `activeCallsChanged` é disparado.
+{% endhint %}
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wavoip/wavoip-api",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "license": "MIT",
     "main": "dist/index.umd.js",
     "types": "dist/index.d.ts",

--- a/src/modules/device/Device.ts
+++ b/src/modules/device/Device.ts
@@ -30,6 +30,7 @@ export class DeviceModel {
     public callType: CallType = "OFFICIAL";
     public restricted = false;
     public restrictedUntil: Date | null = null;
+    public activeCalls = 0;
 
     constructor(public readonly token: string) {}
 

--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -22,6 +22,7 @@ export type DeviceEvents = {
     qrCodeChanged: [qrCode?: string];
     contactChanged: [contact?: Contact];
     restrictedChanged: [restricted: boolean, restrictedUntil: Date | null];
+    activeCallsChanged: [count: number];
 };
 
 type Events = DeviceEvents & {
@@ -36,6 +37,7 @@ export interface Device {
     connectionStatus: ConnectionStatus;
     restricted: boolean;
     restrictedUntil: Date | null;
+    activeCalls: number;
     on<T extends keyof DeviceEvents>(event: T, callback: (...args: DeviceEvents[T]) => void): Unsubscribe;
     /** @deprecated Use `on("statusChanged", callback)` instead. */
     onStatus(cb: (status: DeviceStatus) => void): Unsubscribe;
@@ -76,13 +78,14 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
         this.router.start();
         this.wss.on("disconnect", this.onDisconnect.bind(this));
 
-        this.wss.on("device:init", (status, callType, contact, qrCode, restricted, restrictedUntil) => {
+        this.wss.on("device:init", (status, callType, contact, qrCode, restricted, restrictedUntil, activeCalls) => {
             this.device.status = status;
             this.device.callType = callType;
             this.device.contact = contact ?? undefined;
             this.device.qrCode = qrCode ?? undefined;
             this.device.restricted = restricted;
             this.device.restrictedUntil = restrictedUntil ? new Date(restrictedUntil) : null;
+            this.device.activeCalls = activeCalls ?? 0;
             if (this.device.connectionStatus !== "connected") {
                 this.device.connectionStatus = "connected";
                 this.emit("connectionStatusChanged", this.device.connectionStatus);
@@ -91,6 +94,11 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
             this.emit("contactChanged", this.device.contact);
             this.emit("qrCodeChanged", this.device.qrCode);
             this.emit("restrictedChanged", this.device.restricted, this.device.restrictedUntil);
+            this.emit("activeCallsChanged", this.device.activeCalls);
+        });
+        this.wss.on("device:calls", (count) => {
+            this.device.activeCalls = count;
+            this.emit("activeCallsChanged", count);
         });
         this.wss.on("device:restriction:changed", (restricted, restrictedUntil) => {
             this.device.restricted = restricted;
@@ -169,6 +177,10 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     get restrictedUntil(): Date | null {
         return this.device.restrictedUntil;
+    }
+
+    get activeCalls(): number {
+        return this.device.activeCalls;
     }
 
     get socket(): DeviceSocket {

--- a/src/modules/device/DeviceProxy.ts
+++ b/src/modules/device/DeviceProxy.ts
@@ -13,6 +13,7 @@ export function DeviceProxy(conn: DeviceConnection): Device {
         connectionStatus: conn.connectionStatus,
         restricted: conn.restricted,
         restrictedUntil: conn.restrictedUntil,
+        activeCalls: conn.activeCalls,
 
         on<T extends keyof DeviceEvents>(event: T, callback: (...args: DeviceEvents[T]) => void): Unsubscribe {
             return conn.on(event, callback);

--- a/src/modules/device/WebSocket.ts
+++ b/src/modules/device/WebSocket.ts
@@ -49,6 +49,8 @@ export type ServerEvents = {
         restricted: boolean,
         // Optional: older instance versions omit this arg. Treat undefined as null.
         restrictedUntil?: string | null,
+        // Optional: older instance versions omit this arg. Treat undefined as 0.
+        activeCalls?: number,
     ) => void;
     "device:building": () => void;
     "device:open": (contact: Contact) => void;
@@ -58,6 +60,7 @@ export type ServerEvents = {
     "device:hibernating": () => void;
     // Optional restrictedUntil: older instance versions omit this arg. Treat undefined as null.
     "device:restriction:changed": (restricted: boolean, restrictedUntil?: string | null) => void;
+    "device:calls": (count: number) => void;
 
     "call:offer": (call: { id: string; peer: CallPeer; offer: MediaPlan }, ackOffer: () => void) => void;
     "call:ringing": (callId: string) => void;


### PR DESCRIPTION
## Summary

Surfaces the backend's new active-call count so consumers can render \`ativas / total\` and gate UI (e.g. restart button) on live state.

- Adds \`Device.activeCalls: number\` and \`activeCallsChanged: [count: number]\` on the \`DeviceEvents\` map.
- Handles the new \`device:calls\` server event and reads the trailing \`activeCalls?\` arg on \`device:init\`.
- Only calls in \`CallStatus.ACTIVE\` are counted — ringing offers do **not** count. Matches the backend's \`num_channels\` admission semantics.
- Older backend versions omit the event and the trailing \`device:init\` arg; \`activeCalls\` stays \`0\` in that case and no \`activeCallsChanged\` fires.
- Docs (\`docs/device.md\`, pt-BR): new property row + event section with fallback hint.

## Test plan

- [x] \`pnpm lint\`
- [x] \`pnpm test\`
- [x] \`pnpm build\`
- [ ] Consume from \`client-website\` PR — verify count updates + fallback with older instance.