### PR TITLE
feat(call): surface media-leg reconnect via status DISCONNECTED/ACTIVE

### DIFF
--- a/docs/calls/active.md
+++ b/docs/calls/active.md
@@ -88,7 +88,7 @@ Assine com `call.on(evento, callback)`. Retorna uma função `Unsubscribe`.
 | `iceDiagnostics`    | `IceDiagnostics`    | Diagnóstico da coleta ICE (duração, candidatos por tipo, STUN/TURN alcançados, par selecionado). Replay em listeners tardios. |
 | `connectivityIssue` | `ConnectivityIssue` | Problema de conectividade detectado (`STUN_UNREACHABLE`, `ICE_GATHERING_TIMEOUT`, `ICE_CONNECTION_FAILED`, `NO_HOST_CANDIDATES`, `SYMMETRIC_NAT_SUSPECTED`). Todos os problemas observados são re-emitidos para listeners tardios. |
 | `error`             | `CallFailReason`    | Servidor sinalizou falha da chamada. Veja [`CallFailReason`](../types.md#callfailreason) para a lista de motivos.      |
-| `status`            | `CallStatus`        | Status da chamada mudou.                                                                                               |
+| `status`            | `CallStatus`        | Status da chamada mudou. Durante uma chamada ativa pode emitir `"DISCONNECTED"` quando a perna de mídia do WhatsApp cai e `"ACTIVE"` quando ela se restabelece — é **recuperável** (não terminal), diferente do `connectionStatus` `"disconnected"` do transporte local (esse indica chamada perdida). Use para exibir um indicador de "reconectando". |
 
 ```typescript
 call.on("ended", () => {
@@ -105,6 +105,12 @@ call.on("peerUnmute", () => {
 
 call.on("connectionStatus", (status) => {
     console.log("Transporte:", status)
+})
+
+call.on("status", (status) => {
+    // Perna de mídia do WhatsApp: recuperável, não encerra a chamada.
+    if (status === "DISCONNECTED") showReconnectingBanner()
+    if (status === "ACTIVE")       hideReconnectingBanner()
 })
 
 call.on("error", (err) => {

--- a/src/modules/device/CallRouter.ts
+++ b/src/modules/device/CallRouter.ts
@@ -89,6 +89,17 @@ export class CallRouter {
             call.emit("status", "FAILED");
             this.calls.delete(id);
         });
+        // Media-leg drop/recover for an ACTIVE call. Surfaced as the existing
+        // `status` event ("DISCONNECTED"/"ACTIVE") so consumers can show a
+        // reconnecting indicator. Non-terminal: unlike call:ended/rejected/failed,
+        // the call is NOT removed from `this.calls` — a later call:connected must
+        // still route, and a subsequent terminal event still deletes it.
+        bind("call:disconnected", (id) => {
+            this.calls.get(id)?.emit("status", "DISCONNECTED");
+        });
+        bind("call:connected", (id) => {
+            this.calls.get(id)?.emit("status", "ACTIVE");
+        });
         bind("call:stats", (id, stats) => {
             this.calls.get(id)?.applyServerStats(stats);
         });

--- a/src/modules/device/WebSocket.ts
+++ b/src/modules/device/WebSocket.ts
@@ -68,6 +68,10 @@ export type ServerEvents = {
     "call:accepted": (callId: string) => void;
     "call:rejected": (callId: string) => void;
     "call:ended": (callId: string) => void;
+    // Media-leg flap during an ACTIVE call (WhatsApp socket dropped/recovered).
+    // Non-terminal: the call keeps running, so these do not remove it from routing.
+    "call:disconnected": (callId: string) => void;
+    "call:connected": (callId: string) => void;
     "call:unanswered": (callId: string) => void;
     "call:failed": (callId: string, error: CallFailReason) => void;
     "call:stats": (callId: string, stats: ServerCallStats) => void;

--- a/src/test/device/CallRouter.test.ts
+++ b/src/test/device/CallRouter.test.ts
@@ -235,6 +235,53 @@ describe("CallRouter", () => {
         });
     });
 
+    describe("media reconnect (non-terminal)", () => {
+        it("call:disconnected emits status DISCONNECTED and keeps the Call registered", () => {
+            const socket = makeMockSocket();
+            const router = new CallRouter(socket as unknown as DeviceSocket);
+            router.start();
+            const call = makeCall();
+            router.register(call);
+            const statusCb = vi.fn();
+            call.on("status", statusCb);
+
+            emitSocket(socket, "call:disconnected", call.id);
+
+            expect(statusCb).toHaveBeenCalledWith("DISCONNECTED");
+            expect(router.has(call.id)).toBe(true);
+        });
+
+        it("call:connected emits status ACTIVE and keeps the Call registered", () => {
+            const socket = makeMockSocket();
+            const router = new CallRouter(socket as unknown as DeviceSocket);
+            router.start();
+            const call = makeCall();
+            router.register(call);
+            const statusCb = vi.fn();
+            call.on("status", statusCb);
+
+            emitSocket(socket, "call:disconnected", call.id);
+            emitSocket(socket, "call:connected", call.id);
+
+            expect(statusCb).toHaveBeenNthCalledWith(1, "DISCONNECTED");
+            expect(statusCb).toHaveBeenNthCalledWith(2, "ACTIVE");
+            expect(router.has(call.id)).toBe(true);
+        });
+
+        it("a terminal call:ended after a disconnect still removes the Call", () => {
+            const socket = makeMockSocket();
+            const router = new CallRouter(socket as unknown as DeviceSocket);
+            router.start();
+            const call = makeCall();
+            router.register(call);
+
+            emitSocket(socket, "call:disconnected", call.id);
+            emitSocket(socket, "call:ended", call.id);
+
+            expect(router.has(call.id)).toBe(false);
+        });
+    });
+
     describe("register / unregister", () => {
         it("returned Unsubscribe removes the Call from routing", () => {
             const socket = makeMockSocket();


### PR DESCRIPTION
## Summary
Routes two new backend socket events to the existing `CallActive` `status` event so consumers can show a reconnecting state when the WhatsApp media leg drops during an active call.

## Changes
- `ServerEvents`: add `call:disconnected` / `call:connected`.
- `CallRouter`: bind them → emit `status` `"DISCONNECTED"` (drop) / `"ACTIVE"` (recover). **Non-terminal** — unlike `call:ended`/`rejected`/`failed`, the call is NOT removed from routing, so a later `call:connected` re-routes and a subsequent terminal event still deletes it.
- No new consumer type: `CallStatus` already includes `"DISCONNECTED"`; the `status` event was already plumbed `Call → CallActive`.

## Testing
- `pnpm test` — 260 pass (+3: emit + stays-registered + ended-after-disconnect still deletes)
- `pnpm lint`, `pnpm build` — clean

## Depends on / pairs with
whatsapp_instance emits the `call:disconnected`/`call:connected` wire events (separate PR); webphone renders the resulting `status` (separate PR).