### PR TITLE
fix(device): let backend own call restriction gate

### DIFF
--- a/docs/device.md
+++ b/docs/device.md
@@ -20,7 +20,7 @@ Os dispositivos são retornados por `wavoip.getDevices()`, `wavoip.addDevices()`
 | `connectionStatus` | `ConnectionStatus`     | Estado do WebSocket entre SDK e backend (`connected` / `disconnected` / `reconnecting`).   |
 | `qrCode`           | `string \| undefined`  | String do QR code quando o dispositivo está em `connecting`.                               |
 | `contact`          | `Contact \| undefined` | Número WhatsApp vinculado quando o dispositivo está `open`.                                |
-| `restricted`       | `boolean`              | `true` quando a conta WhatsApp está restrita e impedida de iniciar chamadas.               |
+| `restricted`       | `boolean`              | `true` quando a conta WhatsApp está restrita. Sinal informativo para a UI; o SDK não bloqueia a chamada — o backend decide (uma conta restrita ainda pode ligar para contatos conhecidos). |
 | `restrictedUntil`  | `Date \| null`         | Data em que a restrição expira. `null` quando não há restrição ativa ou data informada.    |
 | `activeCalls`      | `number`               | Quantidade de chamadas ativas no momento (apenas `ACTIVE`; ofertas não contam).            |
 

--- a/src/modules/device/Device.ts
+++ b/src/modules/device/Device.ts
@@ -52,10 +52,6 @@ export class DeviceModel {
             return { err: t("Device is restarting") };
         }
 
-        if (this.restricted) {
-            return { err: t("Device is restricted") };
-        }
-
         return {};
     }
 }

--- a/src/test/device/DeviceConnection.test.ts
+++ b/src/test/device/DeviceConnection.test.ts
@@ -441,14 +441,20 @@ describe("DeviceConnection — calls map cleanup", () => {
             expect(cb).toHaveBeenLastCalledWith(true, expect.any(Date));
         });
 
-        it("startCall returns error when device is restricted", async () => {
+        it("startCall proceeds when device is restricted (backend owns the gate)", async () => {
             const { dc, socket } = makeDeviceConnection();
             socket.receive("device:init", "UP", "UNOFFICIAL", null, null, true);
+            socket.emit.mockImplementation((event: string, ...args: unknown[]) => {
+                if (event === "call.start") {
+                    const callback = args[args.length - 1] as (r: unknown) => void;
+                    callback({ type: "success", result: { id: "call-restricted", type: "UNOFFICIAL", peer } });
+                }
+            });
 
             const result = await dc.startCall("5511999999999");
 
-            expect(result.err).toBeDefined();
-            expect(callsMap(dc).size).toBe(0);
+            expect(result.err).toBeUndefined();
+            expect(callsMap(dc).has("call-restricted")).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## What

Remove client-side restriction gate from `Device.canCall()`. A restricted device is no longer blocked from starting a call by the SDK.

## Why

`canCall()` rejected **every** call when `device.restricted` was true. That is wrong:

- The **unofficial** backend (`whatsapp_instance` `Device.canStartCall(hasTcToken)`) allows a restricted (timelocked) device to reach **known contacts** — those it holds a `tctoken` for. The client cannot know the tctoken, so it can't make this decision.
- The **official (WABA)** engine has **no** restriction gate at all, so the client guard rejected calls the backend would always accept.

Result: legit calls were blocked client-side. The backend is authoritative and returns `DEVICE_RESTRICTED` only when it truly applies.

## Changes

- `src/modules/device/Device.ts` — drop `restricted` check from `canCall()`. `restricted` / `restrictedUntil` stay exposed for UI display; `restrictedChanged` event unchanged.
- `src/test/device/DeviceConnection.test.ts` — flip test: `startCall` now proceeds when restricted (backend owns the gate).
- `docs/device.md` — correct `restricted` description.

## Verification

- `pnpm test` — 260 pass
- `pnpm lint` — clean
- `pnpm build` — ok