### PR TITLE
fix(device): close the socket when disconnecting mid-handshake

### DIFF
--- a/src/modules/device/DeviceConnection.ts
+++ b/src/modules/device/DeviceConnection.ts
@@ -290,7 +290,10 @@ export class DeviceConnection extends EventEmitter<Events> implements Device {
 
     disconnect() {
         this.stopped = true;
-        if (this.wss.disconnected) return;
+        // Always close, even mid-handshake. socket.io reports `disconnected` while
+        // still connecting, so guarding on it would skip the close and leave the
+        // in-flight connection to complete as an orphaned live socket. `disconnect()`
+        // is idempotent and aborts a pending connection.
         this.wss.disconnect();
     }
 

--- a/src/test/device/DeviceConnection.test.ts
+++ b/src/test/device/DeviceConnection.test.ts
@@ -132,6 +132,19 @@ describe("DeviceConnection — manual disconnect", () => {
         expect(socket.connect).not.toHaveBeenCalled();
         vi.useRealTimers();
     });
+
+    it("closes the socket even while still connecting", () => {
+        // Socket.io reports `disconnected: true` until the handshake completes.
+        // disconnect() must still close it, or the in-flight connection survives
+        // as an orphaned live socket (leaving the device page mid-connect).
+        const { dc, socket } = makeDeviceConnection();
+        socket.connected = false;
+        socket.disconnected = true;
+
+        dc.disconnect();
+
+        expect(socket.disconnect).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe("DeviceConnection — connectionStatusChanged on socket disconnect/reconnect", () => {


### PR DESCRIPTION
## Problem
Opening a device page connects a socket; leaving should disconnect it. But leaving **while the socket is still connecting** left the connection alive — reopening quickly accumulated multiple live sockets.

`DeviceConnection.disconnect()`:
```ts
disconnect() {
    this.stopped = true;
    if (this.wss.disconnected) return;   // ← bug
    this.wss.disconnect();
}
```
`this.wss` is a socket.io `Socket`, and socket.io reports `disconnected: true` for the **entire** connecting phase (it just means "not connected yet"). So disconnecting mid-handshake set `stopped = true` and returned **without calling `wss.disconnect()`**. The in-flight handshake then completed as an orphaned live socket. `stopped` only blocks the auto-reconnect path — it can't cancel a connect that already succeeded.

Repro: open a device page → leave before the handshake finishes → reopen. Each cycle leaks a socket.

## Fix
Always call `wss.disconnect()`. It is idempotent in every state and aborts a pending connection.

```ts
disconnect() {
    this.stopped = true;
    this.wss.disconnect();
}
```

## Tests
Added a regression test: `disconnect()` closes the socket even while `disconnected: true` (still connecting). Verified it fails against the old guard and passes with the fix. Full suite: 261 passing; `tsc` + biome clean.
