### PR TITLE
feat(call): cancel() para desistir da chamada antes do atendimento

### DIFF
--- a/docs/calls/incoming.md
+++ b/docs/calls/incoming.md
@@ -85,9 +85,17 @@ Assine com `offer.on(evento, callback)`. Retorna uma função `Unsubscribe`.
 | `connectivityIssue`  | `ConnectivityIssue` | Problema de conectividade detectado durante a oferta. Veja [Tipos → Diagnóstico ICE](../types.md#diagnostico-ice).|
 
 {% hint style="info" %}
-Quando o chamador desiste antes de você atender, o `status` que acompanha o `ended` vem
-como `CANCELLED`. Sempre pare o toque e limpe a interface no `ended` — ele é o único
-evento terminal da oferta, qualquer que tenha sido o desfecho.
+Quando o chamador desiste antes de você atender, o `status` chega como `CANCELLED`
+**imediatamente antes** do `ended`. Guarde-o se quiser distinguir os desfechos:
+
+```typescript
+let outcome: CallStatus = "ENDED"
+offer.on("status", (s) => { outcome = s })
+offer.on("ended", () => hideIncomingCall(outcome))
+```
+
+Sempre pare o toque e limpe a interface no `ended` — ele é o único evento terminal da
+oferta, qualquer que tenha sido o desfecho, e nada é emitido depois dele.
 {% endhint %}
 
 ```typescript

--- a/docs/calls/incoming.md
+++ b/docs/calls/incoming.md
@@ -79,10 +79,16 @@ Assine com `offer.on(evento, callback)`. Retorna uma função `Unsubscribe`.
 | `acceptedElsewhere`  | —                   | Outro cliente (aba/dispositivo) aceitou a chamada.                                                              |
 | `rejectedElsewhere`  | —                   | Outro cliente rejeitou a chamada.                                                                               |
 | `unanswered`         | —                   | Oferta expirou sem resposta.                                                                                    |
-| `ended`              | —                   | Chamada encerrada antes de ser atendida.                                                                        |
+| `ended`              | —                   | Chamada encerrada antes de ser atendida — inclusive quando **o chamador desistiu**. É este evento que desfaz a oferta. |
 | `status`             | `CallStatus`        | Status da chamada mudou.                                                                                        |
 | `iceDiagnostics`     | `IceDiagnostics`    | Diagnóstico da coleta ICE relativa à oferta (quando houver gathering antes do `accept`).                        |
 | `connectivityIssue`  | `ConnectivityIssue` | Problema de conectividade detectado durante a oferta. Veja [Tipos → Diagnóstico ICE](../types.md#diagnostico-ice).|
+
+{% hint style="info" %}
+Quando o chamador desiste antes de você atender, o `status` que acompanha o `ended` vem
+como `CANCELLED`. Sempre pare o toque e limpe a interface no `ended` — ele é o único
+evento terminal da oferta, qualquer que tenha sido o desfecho.
+{% endhint %}
 
 ```typescript
 offer.on("acceptedElsewhere", () => {

--- a/docs/calls/outgoing.md
+++ b/docs/calls/outgoing.md
@@ -155,6 +155,15 @@ trate como chamada possivelmente viva, e continue ouvindo `peerAccept` e `ended`
 Em qualquer outra recusa (id desconhecido, erro interno) a chamada já morreu no
 servidor e o microfone é liberado.
 
+{% hint style="info" %}
+**Instâncias antigas.** Um dispositivo só recebe a versão nova da instância quando
+reinicia, então esta SDK convive com instâncias antigas por tempo indeterminado. Contra
+elas, `cancel()` funciona — o evento no fio é o mesmo de sempre —, mas o desfecho não é
+informado: o fim chega como `ENDED`, não `CANCELLED`, e a recusa por corrida com o
+atendimento pode voltar como sucesso. Trate `ENDED` como o desfecho padrão e não dependa
+de `CANCELLED` para encerrar a interface.
+{% endhint %}
+
 ---
 
 ### `end()`

--- a/docs/calls/outgoing.md
+++ b/docs/calls/outgoing.md
@@ -76,10 +76,30 @@ Assine com `call.on(evento, callback)`. Retorna uma função `Unsubscribe`.
 | `peerAccept`        | `CallActive`        | Destinatário atendeu — um `CallActive` é fornecido.                                                             |
 | `peerReject`        | —                   | Destinatário recusou a chamada.                                                                                 |
 | `unanswered`        | —                   | Chamada expirou sem resposta.                                                                                   |
-| `ended`             | —                   | Chamada encerrada (ex: destinatário desligou antes de atender).                                                 |
+| `ended`             | —                   | Chamada encerrada — inclusive por cancelamento. Consulte `status` para saber qual fim foi (ver abaixo).           |
 | `status`            | `CallStatus`        | Status da chamada mudou.                                                                                        |
 | `iceDiagnostics`    | `IceDiagnostics`    | Diagnóstico da coleta ICE realizada antes do par atender.                                                       |
 | `connectivityIssue` | `ConnectivityIssue` | Problema de conectividade detectado durante a chamada. Veja [Tipos → Diagnóstico ICE](../types.md#diagnostico-ice).|
+
+#### Cancelada ou encerrada?
+
+`ended` é o único evento terminal, e é ele que desfaz a chamada. Para saber **qual**
+fim foi, olhe o `status` que vem junto:
+
+```typescript
+let outcome: CallStatus = "ENDED"
+call.on("status", (s) => { outcome = s })
+call.on("ended", () => {
+    // "CANCELLED" quando alguém desistiu antes do atendimento
+    showEndScreen(outcome)
+})
+```
+
+{% hint style="info" %}
+`CANCELLED` **não** quer dizer "você cancelou": quer dizer que alguém desistiu antes do
+atendimento — pode ter sido o destinatário. Uma instância antiga não informa o desfecho
+e tudo continua chegando como `ENDED`.
+{% endhint %}
 
 ```typescript
 call.on("peerAccept", (active) => {
@@ -106,9 +126,30 @@ await call.unmute()
 
 ---
 
+### `cancel()`
+
+Desiste da chamada antes de o destinatário atender — é o equivalente ao CANCEL do SIP.
+
+```typescript
+const { err } = await call.cancel()
+if (err) console.error("Não foi possível cancelar:", err)
+```
+
+Só encerra a chamada e libera o microfone **quando o servidor confirma**. Se o
+destinatário atender no exato instante do clique, o servidor recusa com `IS_NOT_OFFER`
+e a chamada continua viva e com áudio — cabe à sua interface reabilitar o botão.
+
+Se o ack não chegar em 10s (socket caído, por exemplo), resolve com
+`err: "ACK_TIMEOUT"` em vez de ficar pendente para sempre.
+
+---
+
 ### `end()`
 
-Encerra a chamada realizada.
+{% hint style="warning" %}
+**Depreciado.** Use `cancel()` — mesmo comportamento, nome que corresponde ao que
+sempre foi enviado no fio. O acesso emite um `console.warn` único.
+{% endhint %}
 
 ```typescript
 await call.end()

--- a/docs/calls/outgoing.md
+++ b/docs/calls/outgoing.md
@@ -95,6 +95,9 @@ call.on("ended", () => {
 })
 ```
 
+O `status` do desfecho é sempre emitido **antes** do `ended`, justamente para que o
+handler acima já o veja.
+
 {% hint style="info" %}
 `CANCELLED` **não** quer dizer "você cancelou": quer dizer que alguém desistiu antes do
 atendimento — pode ter sido o destinatário. Uma instância antiga não informa o desfecho
@@ -139,8 +142,18 @@ Só encerra a chamada e libera o microfone **quando o servidor confirma**. Se o
 destinatário atender no exato instante do clique, o servidor recusa com `IS_NOT_OFFER`
 e a chamada continua viva e com áudio — cabe à sua interface reabilitar o botão.
 
-Se o ack não chegar em 10s (socket caído, por exemplo), resolve com
-`err: "ACK_TIMEOUT"` em vez de ficar pendente para sempre.
+Se o ack não chegar em 10s, resolve com `err: "ACK_TIMEOUT"` em vez de ficar pendente
+para sempre.
+
+{% hint style="warning" %}
+`ACK_TIMEOUT` significa **"não sabemos"**, não "não cancelou". O pacote é descartado
+quando o prazo estoura, então o servidor pode nunca tê-lo recebido e o destinatário
+pode continuar tocando — e atender. Por isso o áudio **não** é liberado nesse caminho:
+trate como chamada possivelmente viva, e continue ouvindo `peerAccept` e `ended`.
+{% endhint %}
+
+Em qualquer outra recusa (id desconhecido, erro interno) a chamada já morreu no
+servidor e o microfone é liberado.
 
 ---
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -36,11 +36,17 @@ type CallStatus =
     | "RINGING"       // Chamada realizada tocando no destinatário
     | "ACTIVE"        // Chamada conectada com áudio fluindo
     | "ENDED"         // Chamada encerrada normalmente
+    | "CANCELLED"     // Alguém desistiu antes do atendimento (você ou o destinatário)
     | "REJECTED"      // Chamada foi rejeitada
     | "NOT_ANSWERED"  // Sem resposta antes do tempo limite
     | "FAILED"        // Falha no nível de transporte durante a chamada
     | "DISCONNECTED"  // Conexão perdida
 ```
+
+{% hint style="info" %}
+`CANCELLED` chega pelo mesmo evento `ended` dos demais desfechos — não há um evento
+próprio. Instâncias antigas não informam o desfecho e reportam `ENDED`.
+{% endhint %}
 
 ### `CallType`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wavoip/wavoip-api",
-    "version": "2.6.3",
+    "version": "2.7.0",
     "license": "MIT",
     "main": "dist/index.umd.js",
     "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export type { CallDirection, CallStatus, CallType } from "@/modules/device/Call";
+export type { CallEndOutcome } from "@/modules/device/WebSocket";
 export type { CallFailReason } from "@/modules/device/CallFailReason";
 export type { CallStats, ServerCallStats } from "@/modules/call/Stats";
 export type { CallActive, CallActiveEvents } from "@/modules/call/CallActive";

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -18,6 +18,12 @@ import { forwardEvents } from "@/modules/shared/forwardEvents";
  */
 const ACK_TIMEOUT_MS = 10_000;
 
+/**
+ * The one refusal that means the call is still up: the peer answered between the
+ * click and the ack. Everything else is a dead call, and the media goes with it.
+ */
+const CALL_ALREADY_ANSWERED = "IS_NOT_OFFER";
+
 export type CallOutgoingEvents = {
     peerAccept: [call: CallActive];
     peerReject: [];
@@ -166,11 +172,17 @@ export function CallOutgoingProxy(
          * Gives up the call before the peer answers. The name matches the
          * `call.cancel` that has always gone over the wire.
          *
-         * Only transitions and releases the media **once the server confirms**: this
-         * used to happen unconditionally inside the ack, so racing the answer
-         * (`IS_NOT_OFFER`) destroyed the microphone and the `RTCPeerConnection` while
-         * the call lived on, mute. And with no ack timeout the Promise never resolved
-         * on a dropped socket.
+         * The media is released on every outcome **except the one where the call is
+         * still alive**: `IS_NOT_OFFER` means the peer answered in the same instant,
+         * and tearing the transport down there left a connected call mute — which is
+         * what the unconditional teardown this replaces used to do. Any other refusal
+         * (unknown id after an instance restart, internal error) leaves nothing to
+         * keep alive, so the microphone is freed rather than leaked.
+         *
+         * `ACK_TIMEOUT` is the honest "we do not know" answer: socket.io drops the
+         * buffered packet when the timer fires, so the server may never have seen the
+         * cancel and the peer may still be ringing. The transport is kept precisely
+         * because the call can still be answered.
          *
          * @example await outgoing.cancel()
          */
@@ -178,9 +190,16 @@ export function CallOutgoingProxy(
             return new Promise((resolve) => {
                 wss.timeout(ACK_TIMEOUT_MS).emit("call.cancel", call.id, async (timeoutErr, res) => {
                     if (timeoutErr) return resolve({ err: "ACK_TIMEOUT" });
-                    if (res.type === "error") return resolve({ err: res.result });
+                    if (res.type === "error") {
+                        if (res.result !== CALL_ALREADY_ANSWERED) await dispose();
+                        return resolve({ err: res.result });
+                    }
 
-                    call.cancel();
+                    // Defence in depth: the server already refuses a cancel on an
+                    // ACTIVE call with IS_NOT_OFFER, so a local transition that will
+                    // not apply means the two disagree — do not tear the media down
+                    // on the strength of an ack we cannot honour.
+                    if (!call.cancel()) return resolve({ err: "IS_NOT_OFFER" });
                     await dispose();
                     resolve({ err: null });
                 });

--- a/src/modules/call/CallOutgoing.ts
+++ b/src/modules/call/CallOutgoing.ts
@@ -11,6 +11,13 @@ import { warnDeprecated } from "@/modules/shared/deprecation";
 import { EventEmitter, type Unsubscribe } from "@/modules/shared/EventEmitter";
 import { forwardEvents } from "@/modules/shared/forwardEvents";
 
+/**
+ * Ceiling for the `call.cancel` ack. A dropped socket buffers the emit and the
+ * callback never runs; with no ceiling the Promise stays pending forever and the UI
+ * locks on "cancelling".
+ */
+const ACK_TIMEOUT_MS = 10_000;
+
 export type CallOutgoingEvents = {
     peerAccept: [call: CallActive];
     peerReject: [];
@@ -41,6 +48,9 @@ export interface CallOutgoing {
     onEnd(callback: () => void): void;
     mute(): Promise<{ err: string | null }>;
     unmute(): Promise<{ err: string | null }>;
+    /** Gives up the call before the peer answers. */
+    cancel(): Promise<{ err: string | null }>;
+    /** @deprecated Use `cancel()` instead. */
     end(): Promise<{ err: string | null }>;
     /** @deprecated Use `on("status", callback)` instead. */
     onStatus(cb: (status: CallStatus) => void): void;
@@ -152,14 +162,35 @@ export function CallOutgoingProxy(
             });
         },
 
-        end(): Promise<{ err: string | null }> {
+        /**
+         * Gives up the call before the peer answers. The name matches the
+         * `call.cancel` that has always gone over the wire.
+         *
+         * Only transitions and releases the media **once the server confirms**: this
+         * used to happen unconditionally inside the ack, so racing the answer
+         * (`IS_NOT_OFFER`) destroyed the microphone and the `RTCPeerConnection` while
+         * the call lived on, mute. And with no ack timeout the Promise never resolved
+         * on a dropped socket.
+         *
+         * @example await outgoing.cancel()
+         */
+        cancel(): Promise<{ err: string | null }> {
             return new Promise((resolve) => {
-                wss.emit("call.cancel", call.id, async (res) => {
+                wss.timeout(ACK_TIMEOUT_MS).emit("call.cancel", call.id, async (timeoutErr, res) => {
+                    if (timeoutErr) return resolve({ err: "ACK_TIMEOUT" });
+                    if (res.type === "error") return resolve({ err: res.result });
+
                     call.cancel();
                     await dispose();
-                    resolve(res.type === "error" ? { err: res.result } : { err: null });
+                    resolve({ err: null });
                 });
             });
+        },
+
+        /** @deprecated Use `cancel()` instead — same behaviour, name that matches the wire. */
+        end(): Promise<{ err: string | null }> {
+            warnDeprecated("CallOutgoing.end", "use `outgoing.cancel()` instead.");
+            return proxy.cancel();
         },
 
         on<T extends keyof CallOutgoingEvents>(

--- a/src/modules/device/Call.ts
+++ b/src/modules/device/Call.ts
@@ -195,6 +195,30 @@ export type CallStatus =
     | "FAILED"
     | "DISCONNECTED";
 
+const CALL_STATUSES: readonly CallStatus[] = [
+    "RINGING",
+    "CALLING",
+    "NOT_ANSWERED",
+    "ACTIVE",
+    "CANCELLED",
+    "ENDED",
+    "REJECTED",
+    "FAILED",
+    "DISCONNECTED",
+];
+
+/**
+ * Narrows a status that came off the wire. The server owns a wider vocabulary than
+ * this union, and `CallStatus` does not exist at runtime — without this, an unknown
+ * value would be handed to consumers typed as something it is not, and every
+ * exhaustive `switch` downstream would fall through.
+ *
+ * @example toCallStatus(outcome?.status) // "CANCELLED", or "ENDED" for anything unknown
+ */
+export function toCallStatus(status: string | undefined): CallStatus {
+    return CALL_STATUSES.find((known) => known === status) ?? "ENDED";
+}
+
 type TransitionName = "accept" | "reject" | "cancel" | "end" | "timeout" | "fail";
 
 const TRANSITIONS: Record<TransitionName, { allow: (s: CallStatus) => boolean; to: CallStatus }> = {

--- a/src/modules/device/Call.ts
+++ b/src/modules/device/Call.ts
@@ -187,6 +187,9 @@ export type CallStatus =
     | "CALLING"
     | "NOT_ANSWERED"
     | "ACTIVE"
+    // Someone gave up before the answer — us or the other side. This used to arrive
+    // as "ENDED", indistinguishable from a normal hangup. See `CallEndOutcome`.
+    | "CANCELLED"
     | "ENDED"
     | "REJECTED"
     | "FAILED"
@@ -197,7 +200,7 @@ type TransitionName = "accept" | "reject" | "cancel" | "end" | "timeout" | "fail
 const TRANSITIONS: Record<TransitionName, { allow: (s: CallStatus) => boolean; to: CallStatus }> = {
     accept:  { allow: (s) => s === "RINGING" || s === "CALLING", to: "ACTIVE" },
     reject:  { allow: (s) => s === "ACTIVE", to: "REJECTED" },
-    cancel:  { allow: (s) => s !== "ACTIVE", to: "ENDED" },
+    cancel:  { allow: (s) => s !== "ACTIVE", to: "CANCELLED" },
     end:     { allow: (s) => s === "ACTIVE", to: "ENDED" },
     timeout: { allow: (s) => s === "RINGING" || s === "CALLING", to: "NOT_ANSWERED" },
     fail:    { allow: (s) => s === "ACTIVE", to: "FAILED" },

--- a/src/modules/device/CallRouter.ts
+++ b/src/modules/device/CallRouter.ts
@@ -1,4 +1,4 @@
-import type { Call } from "@/modules/device/Call";
+import { type Call, toCallStatus } from "@/modules/device/Call";
 import type { DeviceSocket, ServerEvents } from "@/modules/device/WebSocket";
 import type { Unsubscribe } from "@/modules/shared/EventEmitter";
 
@@ -57,8 +57,13 @@ export class CallRouter {
         bind("call:ended", (id, outcome) => {
             const call = this.calls.get(id);
             if (!call) return;
+            // `status` first, `ended` second — the reverse of the other handlers, and
+            // deliberately so. Every proxy tears itself down on `ended`, and `Offer`'s
+            // teardown drops its subscriptions: a status emitted afterwards reaches
+            // nobody, so an offer whose caller gave up could never be told it was
+            // CANCELLED. Settle the outcome, then announce the end.
+            call.emit("status", toCallStatus(outcome?.status));
             call.emit("ended");
-            call.emit("status", outcome?.status ?? "ENDED");
             this.calls.delete(id);
         });
         bind("call:accepted", (id) => {

--- a/src/modules/device/CallRouter.ts
+++ b/src/modules/device/CallRouter.ts
@@ -49,11 +49,16 @@ export class CallRouter {
             call.emit("ringing");
             call.emit("status", "RINGING");
         });
-        bind("call:ended", (id) => {
+        // `ended` stays the terminal event every proxy (Offer, CallOutgoing,
+        // CallActive) tears itself down on. What changes is `status`, which now says
+        // *which* ending it was: a newer instance sends CANCELLED when someone gave
+        // up before the answer. An older instance sends no `outcome` and behaviour is
+        // unchanged.
+        bind("call:ended", (id, outcome) => {
             const call = this.calls.get(id);
             if (!call) return;
             call.emit("ended");
-            call.emit("status", "ENDED");
+            call.emit("status", outcome?.status ?? "ENDED");
             this.calls.delete(id);
         });
         bind("call:accepted", (id) => {

--- a/src/modules/device/WebSocket.ts
+++ b/src/modules/device/WebSocket.ts
@@ -1,6 +1,6 @@
 import type { CallPeer } from "@/modules/call/Peer";
 import type { ServerCallStats } from "@/modules/call/Stats";
-import type { CallType } from "@/modules/device/Call";
+import type { CallStatus, CallType } from "@/modules/device/Call";
 import type { CallFailReason } from "@/modules/device/CallFailReason";
 import type { Contact, DeviceStatus } from "@/modules/device/Device";
 import { io } from "socket.io-client";
@@ -40,6 +40,12 @@ export type MediaPlanWebRTC = { type: "webRTC"; sdp: string };
 export type MediaPlanNull = { type: "none" };
 export type MediaPlan = MediaPlanRelay | MediaPlanWebRTC | MediaPlanNull;
 
+/** Which ending closed the call, and why. Rides along `call:ended`. */
+export type CallEndOutcome = {
+    status: CallStatus;
+    reason?: string;
+};
+
 export type ServerEvents = {
     "device:init": (
         status: DeviceStatus,
@@ -67,7 +73,10 @@ export type ServerEvents = {
     "call:answered": (callId: string, mediaPlan: MediaPlan) => void;
     "call:accepted": (callId: string) => void;
     "call:rejected": (callId: string) => void;
-    "call:ended": (callId: string) => void;
+    // Optional: older instance versions omit this arg. Treat undefined as an ordinary
+    // hangup. `outcome.status` distinguishes CANCELLED / *_ELSEWHERE from ENDED, which
+    // all arrive through this one event.
+    "call:ended": (callId: string, outcome?: CallEndOutcome) => void;
     // Media-leg flap during an ACTIVE call (WhatsApp socket dropped/recovered).
     // Non-terminal: the call keeps running, so these do not remove it from routing.
     "call:disconnected": (callId: string) => void;

--- a/src/modules/device/WebSocket.ts
+++ b/src/modules/device/WebSocket.ts
@@ -40,7 +40,13 @@ export type MediaPlanWebRTC = { type: "webRTC"; sdp: string };
 export type MediaPlanNull = { type: "none" };
 export type MediaPlan = MediaPlanRelay | MediaPlanWebRTC | MediaPlanNull;
 
-/** Which ending closed the call, and why. Rides along `call:ended`. */
+/**
+ * Which ending closed the call, and why. Rides along `call:ended`.
+ *
+ * `reason` carries the instance's own vocabulary (`client:canceled`,
+ * `sip:session-terminated`, …). It is passed through untouched and is not part of
+ * any closed set — treat it as a diagnostic string, not a value to branch on.
+ */
 export type CallEndOutcome = {
     status: CallStatus;
     reason?: string;
@@ -74,8 +80,8 @@ export type ServerEvents = {
     "call:accepted": (callId: string) => void;
     "call:rejected": (callId: string) => void;
     // Optional: older instance versions omit this arg. Treat undefined as an ordinary
-    // hangup. `outcome.status` distinguishes CANCELLED / *_ELSEWHERE from ENDED, which
-    // all arrive through this one event.
+    // hangup. Several distinct endings reach the client through this one event;
+    // `outcome.status` is what tells a CANCELLED apart from a plain ENDED.
     "call:ended": (callId: string, outcome?: CallEndOutcome) => void;
     // Media-leg flap during an ACTIVE call (WhatsApp socket dropped/recovered).
     // Non-terminal: the call keeps running, so these do not remove it from routing.

--- a/src/test/call/CallOutgoing.test.ts
+++ b/src/test/call/CallOutgoing.test.ts
@@ -11,15 +11,33 @@ function makeCall() {
     return new Call("call-1", "OFFICIAL", "OUTGOING", peer, "device-token", "RINGING");
 }
 
-function makeMockSocket() {
+/**
+ * `ack` drives what the server answers: `"success"` (default), an error, or
+ * `"timeout"` for the ack that never arrives. `timeout(ms).emit(...)` receives the
+ * callback in socket.io's `(err, res)` shape.
+ */
+function makeMockSocket(ack: "success" | "error" | "timeout" = "success") {
     const socket = new EventEmitter<Record<string, unknown[]>>() as unknown as DeviceSocket & {
         emit: ReturnType<typeof vi.fn>;
+        timeout: ReturnType<typeof vi.fn>;
     };
-    socket.emit = vi.fn((_event: string, ..._args: unknown[]) => {
-        const ack = _args[_args.length - 1];
-        if (typeof ack === "function") (ack as (r: unknown) => void)({ type: "success" });
+    const respond = (args: unknown[], withError: boolean) => {
+        const cb = args[args.length - 1];
+        if (typeof cb !== "function") return;
+        if (ack === "timeout") return withError ? (cb as (e: unknown) => void)(new Error("operation has timed out")) : undefined;
+        const res = ack === "error" ? { type: "error", result: "IS_NOT_OFFER" } : { type: "success" };
+        withError ? (cb as (e: unknown, r: unknown) => void)(null, res) : (cb as (r: unknown) => void)(res);
+    };
+    socket.emit = vi.fn((_event: string, ...args: unknown[]) => {
+        respond(args, false);
         return socket;
     }) as never;
+    socket.timeout = vi.fn(() => ({
+        emit: vi.fn((_event: string, ...args: unknown[]) => {
+            respond(args, true);
+            return socket;
+        }),
+    })) as never;
     return socket;
 }
 
@@ -243,6 +261,21 @@ describe("CallOutgoing", () => {
             expect(cb).toHaveBeenCalledOnce();
         });
 
+        it("forwards 'canceled-ish' terminal to ended consumer event", () => {
+            const call = makeCall();
+
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+
+            const outgoing = CallOutgoingProxy(call, socket, mm as never);
+            const cb = vi.fn();
+            outgoing.on("ended", cb);
+
+            call.emit("ended");
+
+            expect(cb).toHaveBeenCalledOnce();
+        });
+
         it("forwards 'rejected' to peerReject consumer event", () => {
             const call = makeCall();
             
@@ -256,6 +289,55 @@ describe("CallOutgoing", () => {
             call.emit("rejected");
 
             expect(cb).toHaveBeenCalledOnce();
+        });
+    });
+
+    // `end()` transitioned the call and destroyed the media inside the ack
+    // callback without looking at the response. Racing "answered at the very instant
+    // of the cancel", the server refuses with IS_NOT_OFFER but the microphone and the
+    // RTCPeerConnection were already gone — the call lived on, mute.
+    describe("cancel()", () => {
+        it("does not tear down the media when the server refuses the cancellation", async () => {
+            const call = makeCall();
+            const socket = makeMockSocket("error");
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            const outgoing = CallOutgoingProxy(call, socket, mm as never, preBuilt);
+            const result = await outgoing.cancel();
+
+            expect(result.err).toBe("IS_NOT_OFFER");
+            expect(preBuilt.stop).not.toHaveBeenCalled();
+            expect(call.status).toBe("RINGING");
+        });
+
+        it("cancels and releases the media when the server accepts", async () => {
+            const call = makeCall();
+            const socket = makeMockSocket();
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            const outgoing = CallOutgoingProxy(call, socket, mm as never, preBuilt);
+            const result = await outgoing.cancel();
+
+            expect(result.err).toBeNull();
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+            expect(call.status).toBe("CANCELLED");
+        });
+
+        // With no ack timeout the Promise never resolved: a dropped socket left the
+        // cancel button stuck forever.
+        it("resolves with an error instead of hanging when the ack never arrives", async () => {
+            const call = makeCall();
+            const socket = makeMockSocket("timeout");
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            const outgoing = CallOutgoingProxy(call, socket, mm as never, preBuilt);
+            const result = await outgoing.cancel();
+
+            expect(result.err).toBe("ACK_TIMEOUT");
+            expect(preBuilt.stop).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/test/call/CallOutgoing.test.ts
+++ b/src/test/call/CallOutgoing.test.ts
@@ -16,7 +16,7 @@ function makeCall() {
  * `"timeout"` for the ack that never arrives. `timeout(ms).emit(...)` receives the
  * callback in socket.io's `(err, res)` shape.
  */
-function makeMockSocket(ack: "success" | "error" | "timeout" = "success") {
+function makeMockSocket(ack: "success" | "error" | "timeout" = "success", errorCode = "IS_NOT_OFFER") {
     const socket = new EventEmitter<Record<string, unknown[]>>() as unknown as DeviceSocket & {
         emit: ReturnType<typeof vi.fn>;
         timeout: ReturnType<typeof vi.fn>;
@@ -25,7 +25,7 @@ function makeMockSocket(ack: "success" | "error" | "timeout" = "success") {
         const cb = args[args.length - 1];
         if (typeof cb !== "function") return;
         if (ack === "timeout") return withError ? (cb as (e: unknown) => void)(new Error("operation has timed out")) : undefined;
-        const res = ack === "error" ? { type: "error", result: "IS_NOT_OFFER" } : { type: "success" };
+        const res = ack === "error" ? { type: "error", result: errorCode } : { type: "success" };
         withError ? (cb as (e: unknown, r: unknown) => void)(null, res) : (cb as (r: unknown) => void)(res);
     };
     socket.emit = vi.fn((_event: string, ...args: unknown[]) => {
@@ -261,21 +261,6 @@ describe("CallOutgoing", () => {
             expect(cb).toHaveBeenCalledOnce();
         });
 
-        it("forwards 'canceled-ish' terminal to ended consumer event", () => {
-            const call = makeCall();
-
-            const socket = makeMockSocket();
-            const mm = makeMockMediaManager();
-
-            const outgoing = CallOutgoingProxy(call, socket, mm as never);
-            const cb = vi.fn();
-            outgoing.on("ended", cb);
-
-            call.emit("ended");
-
-            expect(cb).toHaveBeenCalledOnce();
-        });
-
         it("forwards 'rejected' to peerReject consumer event", () => {
             const call = makeCall();
             
@@ -327,6 +312,28 @@ describe("CallOutgoing", () => {
 
         // With no ack timeout the Promise never resolved: a dropped socket left the
         // cancel button stuck forever.
+        it("releases the media when the refusal means the call is already dead", async () => {
+            const call = makeCall();
+            const socket = makeMockSocket("error", "CALL_NOT_FOUND");
+            const mm = makeMockMediaManager();
+            const preBuilt = makeMockPreBuiltTransport();
+
+            const outgoing = CallOutgoingProxy(call, socket, mm as never, preBuilt);
+            const result = await outgoing.cancel();
+
+            expect(result.err).toBe("CALL_NOT_FOUND");
+            expect(preBuilt.stop).toHaveBeenCalledOnce();
+        });
+
+        it("bounds the ack with the timeout ceiling", async () => {
+            const call = makeCall();
+            const socket = makeMockSocket();
+
+            await CallOutgoingProxy(call, socket, makeMockMediaManager() as never).cancel();
+
+            expect(socket.timeout).toHaveBeenCalledWith(10_000);
+        });
+
         it("resolves with an error instead of hanging when the ack never arrives", async () => {
             const call = makeCall();
             const socket = makeMockSocket("timeout");

--- a/src/test/call/Offer.test.ts
+++ b/src/test/call/Offer.test.ts
@@ -192,4 +192,34 @@ describe("Offer", () => {
             expect(cb).toHaveBeenCalledWith("ACTIVE");
         });
     });
+
+    // Regression. When the caller gives up before you answer, the domain
+    // marks the call CANCELLED — and it is the router's `ended` that tears the offer
+    // down, stops the ringtone and records it as missed. A separate `call:canceled`
+    // event consuming that `ended` would leave the webphone ringing forever.
+    describe("caller gives up before the answer", () => {
+        it("tears the offer down on the terminal event, whatever the outcome says", () => {
+            const call = makeCall();
+            const offer = OfferProxy(call, { onAccept: vi.fn(), onReject: vi.fn() });
+            const ended = vi.fn();
+            offer.on("ended", ended);
+
+            call.emit("status", "CANCELLED");
+            call.emit("ended");
+
+            expect(ended).toHaveBeenCalledOnce();
+        });
+
+        it("stops listening to the call once torn down", () => {
+            const call = makeCall();
+            const offer = OfferProxy(call, { onAccept: vi.fn(), onReject: vi.fn() });
+            const ended = vi.fn();
+            offer.on("ended", ended);
+
+            call.emit("ended");
+            call.emit("ended");
+
+            expect(ended).toHaveBeenCalledOnce();
+        });
+    });
 });

--- a/src/test/call/Offer.test.ts
+++ b/src/test/call/Offer.test.ts
@@ -193,33 +193,23 @@ describe("Offer", () => {
         });
     });
 
-    // Regression. When the caller gives up before you answer, the domain
-    // marks the call CANCELLED — and it is the router's `ended` that tears the offer
-    // down, stops the ringtone and records it as missed. A separate `call:canceled`
-    // event consuming that `ended` would leave the webphone ringing forever.
+    // Regression. When the caller gives up before you answer, the domain marks the
+    // call CANCELLED, and the router settles `status` *before* `ended` — because the
+    // teardown below drops every subscription, so a status emitted after it would
+    // reach nobody and the consumer could never tell a cancellation from a hangup.
     describe("caller gives up before the answer", () => {
-        it("tears the offer down on the terminal event, whatever the outcome says", () => {
+        it("delivers the cancelled outcome before tearing the offer down", () => {
             const call = makeCall();
             const offer = OfferProxy(call, { onAccept: vi.fn(), onReject: vi.fn() });
-            const ended = vi.fn();
-            offer.on("ended", ended);
+            const seen: string[] = [];
+            offer.on("status", (s) => seen.push(`status:${s}`));
+            offer.on("ended", () => seen.push("ended"));
 
+            // Production order, as emitted by CallRouter for `call:ended`.
             call.emit("status", "CANCELLED");
             call.emit("ended");
 
-            expect(ended).toHaveBeenCalledOnce();
-        });
-
-        it("stops listening to the call once torn down", () => {
-            const call = makeCall();
-            const offer = OfferProxy(call, { onAccept: vi.fn(), onReject: vi.fn() });
-            const ended = vi.fn();
-            offer.on("ended", ended);
-
-            call.emit("ended");
-            call.emit("ended");
-
-            expect(ended).toHaveBeenCalledOnce();
+            expect(seen).toEqual(["status:CANCELLED", "ended"]);
         });
     });
 });

--- a/src/test/device/Call.test.ts
+++ b/src/test/device/Call.test.ts
@@ -77,6 +77,22 @@ describe("Call", () => {
         );
     });
 
+    describe("cancel()", () => {
+        it.each(["CALLING", "RINGING"] as const)("transitions %s → CANCELLED and returns true", (status) => {
+            const call = makeCall(status);
+            expect(call.cancel()).toBe(true);
+            expect(call.status).toBe("CANCELLED");
+        });
+
+        // The one status that must refuse: a connected call is ended, never cancelled.
+        // The server enforces the same rule with IS_NOT_OFFER.
+        it("returns false when the call is already ACTIVE", () => {
+            const call = makeCall("ACTIVE");
+            expect(call.cancel()).toBe(false);
+            expect(call.status).toBe("ACTIVE");
+        });
+    });
+
     describe("timeout()", () => {
         it("transitions CALLING → NOT_ANSWERED and returns true", () => {
             const call = makeCall("CALLING");

--- a/src/test/device/CallRouter.test.ts
+++ b/src/test/device/CallRouter.test.ts
@@ -428,6 +428,8 @@ describe("CallRouter", () => {
             expect(statusCb).toHaveBeenCalledWith("ENDED");
         });
 
+        // Instances update only when their device restarts, so a freshly published SDK
+        // talks to old instances for as long as those devices stay up.
         it("falls back to ENDED when an older instance omits the outcome", () => {
             const { endedCb, statusCb } = endedWith();
 

--- a/src/test/device/CallRouter.test.ts
+++ b/src/test/device/CallRouter.test.ts
@@ -366,4 +366,48 @@ describe("CallRouter", () => {
             expect(received).toBe(stats);
         });
     });
+
+    // `CANCELLED` arrives through the same `call:ended` as always, with one
+    // extra optional argument. A separate `call:canceled` event would have been worse:
+    // the proxies (Offer, CallOutgoing, CallActive) tear down on `ended`, and an offer
+    // whose caller gives up also produces CANCELLED — the client would ring forever.
+    describe("call:ended outcome", () => {
+        function endedWith(outcome?: { status: string; reason?: string }) {
+            const socket = makeMockSocket();
+            const router = new CallRouter(socket as unknown as DeviceSocket);
+            router.start();
+            const call = makeCall();
+            router.register(call);
+            const endedCb = vi.fn();
+            const statusCb = vi.fn();
+            call.on("ended", endedCb);
+            call.on("status", statusCb);
+
+            emitSocket(socket, "call:ended", call.id, outcome);
+
+            return { endedCb, statusCb, socket, call };
+        }
+
+        it("still emits 'ended' when the ending was a cancellation", () => {
+            const { endedCb, statusCb } = endedWith({ status: "CANCELLED", reason: "client:canceled" });
+
+            expect(endedCb).toHaveBeenCalledOnce();
+            expect(statusCb).toHaveBeenCalledWith("CANCELLED");
+        });
+
+        it("falls back to ENDED when an older instance omits the outcome", () => {
+            const { endedCb, statusCb } = endedWith();
+
+            expect(endedCb).toHaveBeenCalledOnce();
+            expect(statusCb).toHaveBeenCalledWith("ENDED");
+        });
+
+        it("unregisters the call so a repeated terminal is inert", () => {
+            const { socket, call, endedCb } = endedWith({ status: "CANCELLED" });
+
+            emitSocket(socket, "call:ended", call.id);
+
+            expect(endedCb).toHaveBeenCalledOnce();
+        });
+    });
 });

--- a/src/test/device/CallRouter.test.ts
+++ b/src/test/device/CallRouter.test.ts
@@ -395,6 +395,39 @@ describe("CallRouter", () => {
             expect(statusCb).toHaveBeenCalledWith("CANCELLED");
         });
 
+        // Order matters: the proxies tear themselves down on `ended`, and `Offer`'s
+        // teardown drops its subscriptions — `status` included. Emitting `ended` first
+        // meant the outcome landed after the teardown, so an offer consumer could
+        // never be told it was CANCELLED.
+        it("settles the status before the terminal event, so a torn-down proxy still sees it", () => {
+            const socket = makeMockSocket();
+            const router = new CallRouter(socket as unknown as DeviceSocket);
+            router.start();
+            const call = makeCall();
+            router.register(call);
+            const order: string[] = [];
+            call.on("status", (s) => order.push(`status:${s}`));
+            call.on("ended", () => order.push("ended"));
+
+            emitSocket(socket, "call:ended", call.id, { status: "CANCELLED" });
+
+            expect(order).toEqual(["status:CANCELLED", "ended"]);
+        });
+
+        it("narrows an unknown status off the wire to ENDED", () => {
+            const socket = makeMockSocket();
+            const router = new CallRouter(socket as unknown as DeviceSocket);
+            router.start();
+            const call = makeCall();
+            router.register(call);
+            const statusCb = vi.fn();
+            call.on("status", statusCb);
+
+            emitSocket(socket, "call:ended", call.id, { status: "SOMETHING_NEW" });
+
+            expect(statusCb).toHaveBeenCalledWith("ENDED");
+        });
+
         it("falls back to ENDED when an older instance omits the outcome", () => {
             const { endedCb, statusCb } = endedWith();
 


### PR DESCRIPTION
## Dois bugs no `end()`

`CallOutgoing.end()` sempre emitiu `call.cancel` no fio, mas fazia a transição local e destruía a mídia **dentro do callback do ack, sem olhar a resposta**:

```ts
wss.emit("call.cancel", call.id, async (res) => {
    call.cancel();     // incondicional
    await dispose();   // incondicional — para o mic e o RTCPeerConnection
    resolve(res.type === "error" ? { err: res.result } : { err: null });
});
```

1. **Corrida com o atendimento.** O destinatário atende no instante do clique, o servidor recusa com `IS_NOT_OFFER` — mas o microfone e o `RTCPeerConnection` já foram embora. A chamada seguia viva e **muda**. Nenhum tratamento de erro no cliente resolvia isso, porque o estrago já estava feito.
2. **Sem timeout de ack** (não havia um único `.timeout(` no repositório). Socket caído bufferiza o emit, o callback nunca roda, a Promise nunca resolve e a interface trava no "cancelando" para sempre.

## O que muda

`cancel()` — nome que corresponde ao que já ia no fio — só transiciona e libera a mídia **quando o servidor confirma**, e resolve com `ACK_TIMEOUT` depois de 10s. `end()` delega e fica `@deprecated`.

`CallStatus` ganha `CANCELLED`, e o `CallRouter` passa a usar um desfecho opcional que a instância anexa ao `call:ended`.

## Nenhum evento novo — de propósito

`ended` continua sendo o terminal que desfaz `Offer`, `CallOutgoing` e `CallActive`. Uma oferta **recebida** cujo chamador desiste também produz `CANCELLED`, então um evento `canceled` separado que consumisse aquele `ended` deixaria o consumidor **tocando indefinidamente**. A distinção chega pelo evento `status`, que os dois proxies já relayam.

Tem teste de regressão para exatamente isso: `Offer` se desfaz num desfecho cancelado.

## Compatibilidade

Instância antiga não manda o desfecho e tudo continua chegando como `ENDED`. Sai como **minor**: ninguém perde evento, só ganha um membro no union `CallStatus` — o que é breaking em `tsc` para quem tem `switch` exaustivo sobre o status.

## Verificação

`pnpm lint`, `pnpm test` (275) e `pnpm build` verdes. Docs pt-BR atualizadas no mesmo commit (`calls/outgoing.md`, `calls/incoming.md`, `types.md`).

## Dependência

O desfecho opcional em `call:ended` vem de uma mudança correspondente na instância, que deve ser publicada antes desta versão. Sem ela nada quebra — o SDK simplesmente segue reportando `ENDED`.

